### PR TITLE
disallow disable-shared builds, remove unneeded nc_initialize_ccr() function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,10 @@ AC_PROG_INSTALL
 # Check to see if any macros must be set to enable large (>2GB) files.
 AC_SYS_LARGEFILE
 
+if test "x$enable_shared" = xno; then
+   AC_MSG_ERROR([Only shared library builds allowed.])
+fi
+
 # Does the user want to enable Fortran library?
 AC_MSG_CHECKING([whether Fortran library should be built])
 AC_ARG_ENABLE([fortran],

--- a/fsrc/ccr.F90
+++ b/fsrc/ccr.F90
@@ -7,13 +7,6 @@
 
 module ccr
 
-  !> Interface to initialization function.
-  interface
-     function nc_initialize_ccr() bind(c)
-       use iso_c_binding
-     end function nc_initialize_ccr
-  end interface
-
   !> Interface to C function to set BZIP2 compression.
   interface
      function nc_def_var_bzip2(ncid, varid, level) bind(c)
@@ -83,15 +76,6 @@ module ccr
   end interface
 
 contains
-  !> Initialize the CCR filters.
-  function nf90_initialize_ccr() result(status)
-    use iso_c_binding
-    implicit none
-    integer :: status
-    integer(C_INT) :: cstatus
-    status = nc_initialize_ccr()
-  end function nf90_initialize_ccr
-
   !> Set BZIP2 compression for a variable.
   !!
   !! @param ncid File or group ID.

--- a/include/ccr.h
+++ b/include/ccr.h
@@ -38,7 +38,6 @@ extern "C" {
 #endif
 
     /* Library prototypes... */
-    int nc_initialize_ccr();
     int nc_def_var_bzip2(int ncid, int varid, int level);
     int nc_inq_var_bzip2(int ncid, int varid, int *bzip2p, int *levelp);
     int nc_def_var_lz4(int ncid, int varid, int level);

--- a/src/ccr.c
+++ b/src/ccr.c
@@ -100,18 +100,6 @@
 #include <H5DSpublic.h>
 
 /**
- * Initialize Community Codec Repository library.
- *
- * @return 0 for success, error code otherwise.
- * @author Ed Hartnett
- */
-int
-nc_initialize_ccr()
-{
-    return 0;
-}
-
-/**
  * Turn on bzip2 compression for a variable.
  *
  * @param ncid File ID.

--- a/test/tst_bitgroom.c
+++ b/test/tst_bitgroom.c
@@ -54,8 +54,6 @@ main()
             for (y = 0; y < NY; y++)
                 data_out[x][y] = x * NY + y;
 
-        if (nc_initialize_ccr()) ERR;
-
         /* Create file. */
         if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
 
@@ -140,8 +138,6 @@ main()
         /* Create some data to write. */
         for (x = 0; x < NX_BIG * NY_BIG; x++)
             data_out[x] = x * NY_BIG + x % NX_BIG;
-
-        /* if (nc_initialize_ccr()) ERR; */
 
         for (f = 0; f < NFILE; f++)
         {

--- a/test/tst_bzip2.c
+++ b/test/tst_bzip2.c
@@ -48,8 +48,6 @@ main()
             for (y = 0; y < NY; y++)
                 data_out[x][y] = x * NY + y;
 
-        if (nc_initialize_ccr()) ERR;
-
         /* Create file. */
         if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
 

--- a/test/tst_lz4.c
+++ b/test/tst_lz4.c
@@ -51,8 +51,6 @@ main()
             for (y = 0; y < NY; y++)
                 data_out[x][y] = x * NY + y;
 
-        if (nc_initialize_ccr()) ERR;
-
         /* Create file. */
         if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
 

--- a/test/tst_zstandard.c
+++ b/test/tst_zstandard.c
@@ -51,8 +51,6 @@ main()
             for (y = 0; y < NY; y++)
                 data_out[x][y] = x * NY + y;
 
-        if (nc_initialize_ccr()) ERR;
-
         /* Create file. */
         if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
 


### PR DESCRIPTION
Fixes #59 

No longer allow --disable-shared builds. I don't know how to make them work, so they always fail. Meanwhile, I often try this by habit because static only makes the debugger a lot easier to use. Now the configure script will remind me not to try this.

Fixes #60 
Fixes #32

Remove the unneeded nc_initialize_ccr() function, and all its spawn.

