### PR TITLE
Turn-on tst_zstandard so make check runs it by default

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,8 +25,8 @@ endif
 # Build BitGroom tests, if needed.
 if BUILD_BITGROOM
 AM_LDFLAGS += ${top_builddir}/hdf5_plugins/BITGROOM/src/libh5bgr.la
-#LDADD += ${top_builddir}/hdf5_plugins/BITGROOM/src/libh5bgr.la
-#TESTS += tst_bitgroom
+TESTS += tst_bitgroom
+tst_bitgroom_LDADD = ${top_builddir}/hdf5_plugins/BITGROOM/src/libh5bgr.la
 endif
 
 # Build Zstandard tests, if needed.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -32,8 +32,8 @@ endif
 # Build Zstandard tests, if needed.
 if BUILD_ZSTANDARD
 AM_LDFLAGS += ${top_builddir}/hdf5_plugins/ZSTANDARD/src/libh5zstd.la
-#LDADD += ${top_builddir}/hdf5_plugins/ZSTANDARD/src/libh5zstd.la
-#TESTS += tst_zstandard
+TESTS += tst_zstandard
+tst_zstandard_LDADD = ${top_builddir}/hdf5_plugins/ZSTANDARD/src/libh5zstd.la
 endif
 
 # Delete files created in testing.


### PR DESCRIPTION
If successful, would address #51 simply by turning the existing test back on. Now that make install is performed before make check and the Bionic plugin directory has been change to runner/plugins, the old test might just work by default.