### PR TITLE
turning on example programs in the build

### DIFF
--- a/hdf5_plugins/BZIP2/example/Makefile.am
+++ b/hdf5_plugins/BZIP2/example/Makefile.am
@@ -10,7 +10,7 @@ LDADD = ${top_builddir}/src/libh5bz2.la
 
 # Build example program and run it as a test.
 check_PROGRAMS = h5ex_d_bzip2
-#TESTS = h5ex_d_bzip2
+TESTS = h5ex_d_bzip2
 
 # Clean up HDF5 file created by example.
 CLEANFILES = *.h5

--- a/hdf5_plugins/LZ4/example/Makefile.am
+++ b/hdf5_plugins/LZ4/example/Makefile.am
@@ -11,7 +11,7 @@ LDADD = ${top_builddir}/src/libh5lz4.la
 
 # Build example program and run it as a test.
 check_PROGRAMS = h5ex_d_lz4
-#TESTS = h5ex_d_lz4
+TESTS = h5ex_d_lz4
 endif
 
 # Clean up HDF5 file created by example.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -6,34 +6,31 @@
 # Find the header files.
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
-AM_LDFLAGS = ${top_builddir}/src/libccr.la ${top_builddir}/hdf5_plugins/BZIP2/src/libh5bz2.la
+AM_LDFLAGS = ${top_builddir}/src/libccr.la
+LDADD = ${top_builddir}/src/libccr.la
 
 # Build the tests.
-check_PROGRAMS = tst_bzip2 tst_lz4 tst_bitgroom tst_zstandard
+check_PROGRAMS = tst_bzip2
 
 # Always run the bzip2 test.
 TESTS = tst_bzip2
-tst_bzip2_LDADD = ${top_builddir}/src/libccr.la ${top_builddir}/hdf5_plugins/BZIP2/src/libh5bz2.la
 
 # Build LZ4 tests, if needed.
 if BUILD_LZ4
-AM_LDFLAGS += ${top_builddir}/hdf5_plugins/LZ4/src/libh5lz4.la
 TESTS += tst_lz4
-tst_lz4_LDADD = ${top_builddir}/src/libccr.la ${top_builddir}/hdf5_plugins/LZ4/src/libh5lz4.la
+check_PROGRAMS += tst_lz4
 endif
 
 # Build BitGroom tests, if needed.
 if BUILD_BITGROOM
-AM_LDFLAGS += ${top_builddir}/hdf5_plugins/BITGROOM/src/libh5bgr.la
 TESTS += tst_bitgroom
-tst_bitgroom_LDADD = ${top_builddir}/hdf5_plugins/BITGROOM/src/libh5bgr.la
+check_PROGRAMS += tst_bitgroom
 endif
 
 # Build Zstandard tests, if needed.
 if BUILD_ZSTANDARD
-AM_LDFLAGS += ${top_builddir}/hdf5_plugins/ZSTANDARD/src/libh5zstd.la
 TESTS += tst_zstandard
-tst_zstandard_LDADD = ${top_builddir}/hdf5_plugins/ZSTANDARD/src/libh5zstd.la
+check_PROGRAMS += tst_zstandard
 endif
 
 # Delete files created in testing.


### PR DESCRIPTION
Fixes #41

Turning on some tests I couldn't get working before due to HDF5_PLUGIN_PATH confusion.

Part of #30 

Also eliminate links to plugins in tests. We don't need to link to them, HDF5 does that dynamically.