### PR TITLE
Improve BitGroom success check by comparing with rint() rounding

### DIFF
--- a/hdf5_plugins/BITGROOM/example/h5ex_d_bitgroom.c
+++ b/hdf5_plugins/BITGROOM/example/h5ex_d_bitgroom.c
@@ -49,7 +49,7 @@ main (void)
     unsigned int    flags;
     unsigned        filter_config;
     const unsigned int    cd_values[5] = {3,4,0,0,0}; /* BitGroom default is NSD,sizeof(data),has_mss_val,mss_val_byt_1to4[,mss_val_byt_5to8] */
-    unsigned int    values_out[6] = {99,99,99,99,99};
+    unsigned int    values_out[5] = {99,99,99,99,99};
     float           wdata[DIM0][DIM1],          /* Write buffer */
                     rdata[DIM0][DIM1],          /* Read buffer */
                     max;
@@ -83,6 +83,8 @@ main (void)
     dcpl_id = H5Pcreate (H5P_DATASET_CREATE);
     if (dcpl_id < 0) goto done;
 
+    /* 20200929: csz change this to H5Z_FLAG_OPTIONAL, so that can_apply() can reject filter for
+       integers without causing program to exit()? */
     status = H5Pset_filter (dcpl_id, H5Z_FILTER_BITGROOM, H5Z_FLAG_MANDATORY, nelmts, cd_values);
     if (status < 0) goto done;
 
@@ -95,7 +97,7 @@ main (void)
         status = H5Zget_filter_info (H5Z_FILTER_BITGROOM, &filter_config);
         if ( (filter_config & H5Z_FILTER_CONFIG_ENCODE_ENABLED) &&
 	     (filter_config & H5Z_FILTER_CONFIG_DECODE_ENABLED) )
-	  printf ("BitGroom filter is available for encoding and decoding.\n");
+	  printf ("BitGroom filter is available for quantization and decoding.\n");
     }
     else {
         printf ("H5Zfilter_avail - not found.\n");

--- a/test/tst_bitgroom.c
+++ b/test/tst_bitgroom.c
@@ -52,7 +52,7 @@ main()
         /* Create some data to write. */
         for (x = 0; x < NX; x++)
             for (y = 0; y < NY; y++)
-                data_out[x][y] = x * NY + y;
+	      data_out[x][y] = x * NY + y;
 
         /* Create file. */
         if (nc_create(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
@@ -98,6 +98,7 @@ main()
 
         {
             float data_in[NX][NY];
+	    float data_tst[NX][NY];
 
             /* Now reopen the file and check. */
             if (nc_open(FILE_NAME, NC_NETCDF4, &ncid)) ERR;
@@ -112,11 +113,14 @@ main()
 
             /* Check the data. Quantization alter data, so do not check for equality :) */
 	    /* fxm: replace this with better test using round((x*10^NSD)/10^NSD) */
+	    double scale=pow(10.0,nsd_in);
             for (x = 0; x < NX; x++)
                for (y = 0; y < NY; y++)
-		 if (round(data_in[x][y]) <= data_out[x][y]-2 ||
-		     round(data_in[x][y]) >= data_out[x][y]+2 ) ERR;
-
+		 {
+		   data_tst[x][y]=rint(scale*data_out[x][y])/scale;
+		   //(void)printf("dat_rgn = %g, dat_bgr = %g, dat_tst = %g\n",data_out[x][y],data_in[x][y],data_tst[x][y]);
+		   if (fabs(data_in[x][y]-data_tst[x][y]) > 1.0) ERR;
+		 }
             /* Close the file. */
             if (nc_close(ncid)) ERR;
         }

--- a/test/tst_bitgroom.c
+++ b/test/tst_bitgroom.c
@@ -112,14 +112,13 @@ main()
             if (nc_get_var(ncid, varid, data_in)) ERR;
 
             /* Check the data. Quantization alter data, so do not check for equality :) */
-	    /* fxm: replace this with better test using round((x*10^NSD)/10^NSD) */
 	    double scale=pow(10.0,nsd_in);
             for (x = 0; x < NX; x++)
                for (y = 0; y < NY; y++)
 		 {
 		   data_tst[x][y]=rint(scale*data_out[x][y])/scale;
 		   //(void)printf("dat_rgn = %g, dat_bgr = %g, dat_tst = %g\n",data_out[x][y],data_in[x][y],data_tst[x][y]);
-		   if (fabs(data_in[x][y]-data_tst[x][y]) > 1.0) ERR;
+		   if (fabs(data_in[x][y]-data_tst[x][y]) > fabs(5.0*data_out[x][y]/scale)) ERR;
 		 }
             /* Close the file. */
             if (nc_close(ncid)) ERR;


### PR DESCRIPTION
Lossy algorithms evaluate success by exact comparison against original input. Here we implement compare BitGroom'd values to rint()'d values. Current comparison works for NSD=3. Could generalize to work for all NSD  by changing input array.