### PR TITLE
Add checks for features_h need by recent GCC to define __USE_BSD used…

### DIFF
--- a/hdf5_plugins/BITGROOM/configure.ac
+++ b/hdf5_plugins/BITGROOM/configure.ac
@@ -52,7 +52,7 @@ AC_SEARCH_LIBS([H5Fflush], [hdf5dll hdf5], [], [AC_MSG_ERROR([libhdf5 is require
 
 # Check for other header files we need.
 AC_HEADER_STDC
-AC_CHECK_HEADERS([fcntl.h math.h stdlib.h string.h])
+AC_CHECK_HEADERS([fcntl.h features.h math.h stdlib.h string.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/hdf5_plugins/BITGROOM/src/H5Zbitgroom.c
+++ b/hdf5_plugins/BITGROOM/src/H5Zbitgroom.c
@@ -49,6 +49,10 @@
 #endif
 
 /* Standard header files */
+#ifdef HAVE_FEATURES_H
+/* Needed to define __USE_BSD that recent GCC compilers use in math.h to define M_LN2... */
+# include <features.h> /* __USE_BSD */
+#endif
 #ifdef HAVE_MATH_H
 /* Needed for M_LN10, M_LN2 in ccr_bgr() */
 # include <math.h> /* sin cos cos sin 3.14159 */


### PR DESCRIPTION
Recent GCC defines __USE_BSD in features.h, and uses that in math.h for M_LN2, M_LN10