### PR TITLE
Fix distcheck target, add distcheck CI test, update version number to 1.1.0

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -79,5 +79,6 @@ jobs:
       run: |
         echo $HDF5_PLUGIN_PATH
         autoreconf -i
-        ./configure --enable-docs --prefix=/home/runner/inst --with-hdf5-plugin-path=/home/runner/plugin --enable-fortran
-        make -j check
+        export DISTCHECK_CONFIGURE_FLAGS="--with-hdf5-plugin-path=/home/runner/plugin --enable-fortran"
+        ./configure --with-hdf5-plugin-path=/home/runner/plugin --enable-fortran
+        make -j distcheck

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 AC_PREREQ([2.59])
 
 # Initialize with name, version, and support email address.
-AC_INIT([ccr], [1.1-development], [])
+AC_INIT([ccr], [1.1.0], [])
 
 AM_INIT_AUTOMAKE([foreign dist-zip subdir-objects])
 

--- a/configure.ac
+++ b/configure.ac
@@ -73,9 +73,9 @@ fi
 # subdirs, and also handled by the configure in each filter
 # subdirectory.
 AC_MSG_CHECKING([where to put HDF5 plugins])
-AC_ARG_WITH([hdf5-plugin-dir],
-            [AS_HELP_STRING([--with-hdf5-plugin-dir=<directory>],
-                            [specify HDF5 plugin directory (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
+AC_ARG_WITH([hdf5-plugin-path],
+            [AS_HELP_STRING([--with-hdf5-plugin-path=<directory>],
+                            [specify HDF5 plugin path (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
             [HDF5_PLUGIN_PATH=$with_hdf5_plugin_path])
 HDF5_PLUGIN_PATH=${HDF5_PLUGIN_PATH-.}
 AC_MSG_RESULT($HDF5_PLUGIN_PATH)

--- a/hdf5_plugins/BITGROOM/configure.ac
+++ b/hdf5_plugins/BITGROOM/configure.ac
@@ -25,12 +25,12 @@ AC_PROG_INSTALL
 LT_INIT(dlopen)
 
 # If the env. variable HDF5_PLUGIN_PATH is set, or if
-# --with-hdf5-plugin-dir=<directory>, use it as a place for the large
+# --with-hdf5-plugin-path=<directory>, use it as a place for the large
 # (i.e. > 2 GiB) files created during the large file testing.
 AC_MSG_CHECKING([where to put HDF5 plugins])
 HDF5_PLUGIN_PATH=${HDF5_PLUGIN_PATH-'/usr/local/hdf5/lib/plugin'}
-AC_ARG_WITH([hdf5-plugin-dir],
-            [AS_HELP_STRING([--with-hdf5-plugin-dir=<directory>],
+AC_ARG_WITH([hdf5-plugin-path],
+            [AS_HELP_STRING([--with-hdf5-plugin-path=<directory>],
                             [specify HDF5 plugin directory (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
             [HDF5_PLUGIN_PATH=$with_hdf5_plugin_path])
 AC_MSG_RESULT($HDF5_PLUGIN_PATH)

--- a/hdf5_plugins/BZIP2/configure.ac
+++ b/hdf5_plugins/BZIP2/configure.ac
@@ -24,13 +24,13 @@ AC_PROG_INSTALL
 LT_INIT(dlopen)
 
 # If the env. variable HDF5_PLUGIN_PATH is set, or if
-# --with-hdf5-plugin-dir=<directory>, use it as a place for the large
+# --with-hdf5-plugin-path=<directory>, use it as a place for the large
 # (i.e. > 2 GiB) files created during the large file testing.
 AC_MSG_CHECKING([where to put HDF5 plugins])
 HDF5_PLUGIN_PATH=${HDF5_PLUGIN_PATH-'/usr/local/hdf5/lib/plugin'}
-AC_ARG_WITH([hdf5-plugin-dir],
-            [AS_HELP_STRING([--with-hdf5-plugin-dir=<directory>],
-                            [specify HDF5 plugin directory (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
+AC_ARG_WITH([hdf5-plugin-path],
+            [AS_HELP_STRING([--with-hdf5-plugin-path=<directory>],
+                            [specify HDF5 plugin path (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
             [HDF5_PLUGIN_PATH=$with_hdf5_plugin_path])
 AC_MSG_RESULT($HDF5_PLUGIN_PATH)
 AC_SUBST([HDF5_PLUGIN_PATH])

--- a/hdf5_plugins/LZ4/configure.ac
+++ b/hdf5_plugins/LZ4/configure.ac
@@ -26,9 +26,9 @@ LT_INIT(dlopen)
 # (i.e. > 2 GiB) files created during the large file testing.
 AC_MSG_CHECKING([where to put HDF5 plugins])
 HDF5_PLUGIN_PATH=${HDF5_PLUGIN_PATH-'/usr/local/hdf5/lib/plugin'}
-AC_ARG_WITH([hdf5-plugin-dir],
-            [AS_HELP_STRING([--with-hdf5-plugin-dir=<directory>],
-                            [specify HDF5 plugin directory (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
+AC_ARG_WITH([hdf5-plugin-path],
+            [AS_HELP_STRING([--with-hdf5-plugin-path=<directory>],
+                            [specify HDF5 plugin path (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
             [HDF5_PLUGIN_PATH=$with_hdf5_plugin_path])
 AC_MSG_RESULT($HDF5_PLUGIN_PATH)
 AC_SUBST([HDF5_PLUGIN_PATH])

--- a/hdf5_plugins/ZSTANDARD/configure.ac
+++ b/hdf5_plugins/ZSTANDARD/configure.ac
@@ -25,13 +25,13 @@ AC_PROG_INSTALL
 LT_INIT(dlopen)
 
 # If the env. variable HDF5_PLUGIN_PATH is set, or if
-# --with-hdf5-plugin-dir=<directory>, use it as a place for the large
+# --with-hdf5-plugin-path=<directory>, use it as a place for the large
 # (i.e. > 2 GiB) files created during the large file testing.
 AC_MSG_CHECKING([where to put HDF5 plugins])
 HDF5_PLUGIN_PATH=${HDF5_PLUGIN_PATH-'/usr/local/hdf5/lib/plugin'}
-AC_ARG_WITH([hdf5-plugin-dir],
-            [AS_HELP_STRING([--with-hdf5-plugin-dir=<directory>],
-                            [specify HDF5 plugin directory (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
+AC_ARG_WITH([hdf5-plugin-path],
+            [AS_HELP_STRING([--with-hdf5-plugin-path=<directory>],
+                            [specify HDF5 plugin path (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
             [HDF5_PLUGIN_PATH=$with_hdf5_plugin_path])
 AC_MSG_RESULT($HDF5_PLUGIN_PATH)
 AC_SUBST([HDF5_PLUGIN_PATH])

--- a/hdf5_plugins/configure.ac
+++ b/hdf5_plugins/configure.ac
@@ -17,15 +17,15 @@ LT_PREREQ([2.4])
 LT_INIT()
 
 # If the env. variable HDF5_PLUGIN_PATH is set, or if
-# --with-hdf5-plugin-dir=<directory>, use it as the plugin
+# --with-hdf5-plugin-path=<directory>, use it as the plugin
 # directory. This is necessary at the top level to provide the help
 # message and --with option. If used, the option will be passed to the
 # subdirs, and also handled by the configure in each filter
 # subdirectory.
 AC_MSG_CHECKING([where to put HDF5 plugins])
-AC_ARG_WITH([hdf5-plugin-dir],
-            [AS_HELP_STRING([--with-hdf5-plugin-dir=<directory>],
-                            [specify HDF5 plugin directory (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
+AC_ARG_WITH([hdf5-plugin-path],
+            [AS_HELP_STRING([--with-hdf5-plugin-path=<directory>],
+                            [specify HDF5 plugin path (defaults to /usr/local/hdf5/lib/plugin, or value of HDF5_PLUGIN_PATH, if set)])],
             [HDF5_PLUGIN_PATH=$with_hdf5_plugin_path])
 HDF5_PLUGIN_PATH=${HDF5_PLUGIN_PATH-.}
 AC_MSG_RESULT($HDF5_PLUGIN_PATH)


### PR DESCRIPTION
Fixes #42 

After this PR make distcheck works. (--with-hdf5-plugin-path must be used to set the plugin path to one that you have permission to install in.)

This command worked for me:

`CFLAGS='-g -Wall' CPPFLAGS='-I/usr/local/netcdf-fortran-4.5.3_netcdf-c-4.7.4_mpich/include -I/usr/local/hdf5-1.10.6_mpich/include -I/usr/local/netcdf-c-4.7.4_hdf5-1.10.6_szip_mpich/include' LDFLAGS='-L/usr/local/netcdf-fortran-4.5.3_netcdf-c-4.7.4_mpich/lib -L/usr/local/hdf5-1.10.6_mpich/lib -L/usr/local/netcdf-c-4.7.4_hdf5-1.10.6_szip_mpich/lib' DISTCHECK_CONFIGURE_FLAGS="--enable-fortran --with-hdf5-plugin-path=/home/ed/tmp" make -j distcheck`

Part of #82 

Also updated the package version number to 1.1.0.