### PR TITLE
ensure config.h is being included first in all tests

### DIFF
--- a/hdf5_plugins/BITGROOM/example/h5ex_d_bitgroom.c
+++ b/hdf5_plugins/BITGROOM/example/h5ex_d_bitgroom.c
@@ -19,7 +19,7 @@
   to discover, load and register filters at run time.
 
  ************************************************************/
-
+#include "config.h"
 #include "hdf5.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/hdf5_plugins/BZIP2/example/h5ex_d_bzip2.c
+++ b/hdf5_plugins/BZIP2/example/h5ex_d_bzip2.c
@@ -20,6 +20,7 @@
 
  ************************************************************/
 
+#include "config.h"
 #include "hdf5.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/hdf5_plugins/LZ4/example/h5ex_d_lz4.c
+++ b/hdf5_plugins/LZ4/example/h5ex_d_lz4.c
@@ -20,6 +20,7 @@
 
  ************************************************************/
 
+#include "config.h"
 #include "hdf5.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/hdf5_plugins/ZSTANDARD/example/h5ex_d_zstandard.c
+++ b/hdf5_plugins/ZSTANDARD/example/h5ex_d_zstandard.c
@@ -19,7 +19,7 @@
   to discover, load and register filters at run time.
 
  ************************************************************/
-
+#include "config.h"
 #include "hdf5.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/tst_bitgroom.c
+++ b/test/tst_bitgroom.c
@@ -5,8 +5,8 @@
    Charlie Zender 9/18/20, Ed Hartnett 1/20/20
 */
 
+#include "config.h"
 #include <math.h> /* Needed for round() test */
-
 #include "ccr.h"
 #include "ccr_test.h"
 #include <hdf5.h>

--- a/test/tst_bzip2.c
+++ b/test/tst_bzip2.c
@@ -8,6 +8,7 @@
    either.
 */
 
+#include "config.h"
 #include "ccr.h"
 #include "ccr_test.h"
 #include <hdf5.h>

--- a/test/tst_lz4.c
+++ b/test/tst_lz4.c
@@ -5,6 +5,7 @@
    Ed Hartnett 1/20/20
 */
 
+#include "config.h"
 #include "ccr.h"
 #include "ccr_test.h"
 #include <hdf5.h>

--- a/test/tst_zstandard.c
+++ b/test/tst_zstandard.c
@@ -5,6 +5,7 @@
    Charlie Zender 9/18/20, Ed Hartnett 1/20/20
 */
 
+#include "config.h"
 #include "ccr.h"
 #include "ccr_test.h"
 #include <hdf5.h>

--- a/test_h5/tst_h_bitgroom.c
+++ b/test_h5/tst_h_bitgroom.c
@@ -6,6 +6,7 @@
  * Charlie Zender 9/19/20
  */
 
+#include "config.h"
 #include "ccr_test.h"
 #include <hdf5.h>
 #include <H5DSpublic.h>

--- a/test_h5/tst_h_bzip2.c
+++ b/test_h5/tst_h_bzip2.c
@@ -7,6 +7,7 @@
  * 12/30/19
 */
 
+#include "config.h"
 #include "ccr_test.h"
 #include <hdf5.h>
 #include <H5DSpublic.h>

--- a/test_h5/tst_h_lz4.c
+++ b/test_h5/tst_h_lz4.c
@@ -7,6 +7,7 @@
  * 12/30/19
  */
 
+#include "config.h"
 #include "ccr_test.h"
 #include <hdf5.h>
 #include <H5DSpublic.h>

--- a/test_h5/tst_lz4_size.c
+++ b/test_h5/tst_lz4_size.c
@@ -4,6 +4,7 @@
  * This is a test for the LZ4 filter.
  */
 
+#include "config.h"
 #include "ccr_test.h"
 #include "hdf5.h"
 #include <stdio.h>

--- a/test_h5/tst_zstandard_size.c
+++ b/test_h5/tst_zstandard_size.c
@@ -4,6 +4,7 @@
  * This is a test for the Zstandard filter.
  */
 
+#include "config.h"
 #include "ccr_test.h"
 #include "hdf5.h"
 #include <stdio.h>


### PR DESCRIPTION
Fixes #86 

config.h must always be included in all tests, and be the very first include.

