### PR TITLE
Use cd_value[5] instead of scalar cd_value ...

### DIFF
--- a/hdf5_plugins/BITGROOM/example/h5ex_d_bitgroom.c
+++ b/hdf5_plugins/BITGROOM/example/h5ex_d_bitgroom.c
@@ -45,10 +45,10 @@ main (void)
     char            filter_name[80];
     hsize_t         dims[2] = {DIM0, DIM1},
                     chunk[2] = {CHUNK0, CHUNK1};
-    size_t          nelmts = 5;                /* number of elements in cd_values */
+    size_t          nelmts = 5; /* number of elements in cd_values */ /* NB: Must equal H5Zbitgroom.c: CCR_FLT_PRM_NBR */
     unsigned int    flags;
     unsigned        filter_config;
-    const unsigned int    cd_values[5] = {3,4,0,0,0}; /* BitGroom default is NSD,sizeof(data),has_mss_val,mss_val_byt_1to4[,mss_val_byt_5to8] */
+    const unsigned int    cd_values[5] = {3,4,0,0,0}; /* BitGroom argument ordering is NSD,sizeof(data),has_mss_val,mss_val_byt_1to4[,mss_val_byt_5to8] */
     unsigned int    values_out[5] = {99,99,99,99,99};
     float           wdata[DIM0][DIM1],          /* Write buffer */
                     rdata[DIM0][DIM1],          /* Read buffer */
@@ -120,7 +120,8 @@ main (void)
      * Write the data to the dataset.
      */
     printf ("....Writing BitGroom-quantized data ................\n");
-    status = H5Dwrite (dset_id, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wdata[0]);
+    //    status = H5Dwrite (dset_id, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wdata[0]);
+    status = H5Dwrite (dset_id, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, (void *)wdata);
     if (status < 0) printf ("failed to write data.\n");
 
     /*

--- a/src/ccr.c
+++ b/src/ccr.c
@@ -295,14 +295,14 @@ nc_inq_var_lz4(int ncid, int varid, int *lz4p, int *levelp)
 int
 nc_def_var_bitgroom(int ncid, int varid, int nsd)
 {
-  /* NB: Internally, the filter requires six elements for cd_value
-     However, only the first element, NSD, is required, as the other
-     arguments can be and are derived from the dcpl (data_class, datum_size),
+  /* NB: Internally, the filter requires CCR_FLT_PRM_NBR (=5) elements for cd_value
+     However, the user needs to provide only the first element, NSD, since the other
+     elements can be and are derived from the dcpl (data_class, datum_size),
      and extra queries of the variable (has_mss_val, mss_val).
-     Hence, we expose and require only the minimal number (1) of 
-     filter parameters to the netCDF mechanism.
+     Hence, the netCDF API exposes to the user and requires setting only the 
+     minimal number (1) of filter parameters.
      Everything else should be automagical (knock on wood). */ 
-  unsigned int cd_value = nsd;
+  unsigned int cd_value[BITGROOM_FLT_PRM_NBR];
   int ret;
   
   /* NSD must be between 1 and 15 */
@@ -314,9 +314,12 @@ nc_def_var_bitgroom(int ncid, int varid, int nsd)
       printf ("BitGroom filter not available.\n");
       return NC_EFILTER;
     }
-  
+
+  /* User-provided NSD is first element of filter parameter array */
+  cd_value[0] = nsd;
+
   /* Set up the BitGroom filter for this var. */
-  if ((ret = nc_def_var_filter(ncid, varid, BITGROOM_ID, BITGROOM_FLT_PRM_NBR, &cd_value)))
+  if ((ret = nc_def_var_filter(ncid, varid, BITGROOM_ID, BITGROOM_FLT_PRM_NBR, cd_value)))
     return ret;
 
   return 0;


### PR DESCRIPTION
in nc_def_var_bitgroom() to avoid stack buffer overflow. This is intended to address #98.