### PR TITLE
Add build summary, determine some things about  netcdf-c library being used

### DIFF
--- a/.github/workflows/build_par.yml
+++ b/.github/workflows/build_par.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Installs
       run: |
         sudo apt-get install doxygen graphviz liblz4-dev libzstd-dev
+    - name: cache-mpich
+      id: cache-mpich
+      uses: actions/cache@v2
+      with:
+        path: ~/mpich
+        key: mpich-${{ runner.os }}-3.3.2
     - name: build-mpich
       if: steps.cache-mpich.outputs.cache-hit != 'true'
       run: |

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,4 +21,10 @@ endif
 SUBDIRS = hdf5_plugins include src $(FSRC) $(FTEST) test_h5 test	\
 $(DOCS)
 
-EXTRA_DIST = LICENSE README.md
+# install libccr.settings in lib directory.
+settingsdir = $(libdir)
+settings_DATA = libccr.settings
+
+DISTCLEANFILES = libccr.settings
+
+EXTRA_DIST = LICENSE README.md libccr.settings.in

--- a/ccr-config.in
+++ b/ccr-config.in
@@ -21,6 +21,8 @@ has_bzip2="@BUILD_BZIP2@"
 has_lz4="@BUILD_LZ4@"
 has_zstd="@BUILD_ZSTD@"
 version="@PACKAGE_NAME@ @PACKAGE_VERSION@"
+has_par="@HAS_NETCDF_PAR@"
+has_multifilters="@HAS_MULTIFILTERS@"
 
 has_fortran="@BUILD_FORTRAN@"
 has_f90="no"
@@ -49,6 +51,8 @@ Available values for OPTION include:
   --has-fortran   whether Fortran API is installed
   --has-lz4       whether LZ4 filter is installed
   --has-zstd      whether Zstandard filter is installed
+  --has-par       whether Parallel I/O is enabled
+  --has-multifilters  whether Multifilters are enabled
   --help          display this help message and exit
   --includedir    Include directory
   --libdir        Library directory
@@ -92,6 +96,8 @@ fi
         echo "  --has-bzip2     -> $has_bzip2"
         echo "  --has-lz4       -> $has_lz4"
         echo "  --has-zstd      -> $has_zstd"
+        echo "  --has-par       -> $has_par"
+        echo "  --has-multifilters      -> $has_multifilters"
         echo
         echo "  --prefix        -> $prefix"
         echo "  --includedir    -> $includedir"
@@ -145,6 +151,14 @@ while test $# -gt 0; do
 
     --has-zstd)
         echo $has_zstd
+        ;;
+
+    --has-par)
+        echo $has_par
+        ;;
+
+    --has-multifilters)
+        echo $has_multifilters
         ;;
 
     --libs)

--- a/configure.ac
+++ b/configure.ac
@@ -349,6 +349,9 @@ AC_DEFUN([AX_SET_META],[
 ])
 
 # Settings for libccr.settings and ccr_meta.h.
+AC_SUBST(HAS_LZ4,[$enable_lz4])
+AX_SET_META([CCR_HAS_LZ4],[$enable_lz4],[yes])
+
 AX_SET_META([CCR_HAS_MULTIFILTERS],[$have_multifilters],[yes])
 
 # THis is the text summary and header file of how CCR was built.

--- a/configure.ac
+++ b/configure.ac
@@ -209,7 +209,7 @@ AC_SEARCH_LIBS([nc_create], [netcdf], [],
                             [AC_MSG_ERROR([Can't find or link to the netCDF C library, set CPPFLAGS/LDFLAGS.])])
 AC_CHECK_HEADERS([netcdf.h netcdf_meta.h])
 
-# Do we have netCDF-4?
+# Do we have netCDF-4? If not, we're done.
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "netcdf_meta.h"],
 [[#if !NC_HAS_NC4
 # error
@@ -217,38 +217,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "netcdf_meta.h"],
 ])], [have_netcdf4=yes], [have_netcdf4=no])
 AC_MSG_CHECKING([whether netCDF provides netCDF/HDF5])
 AC_MSG_RESULT([${have_netcdf4}])
-
-# Do we have a parallel build of netCDF-4? (Really we should be
-# checking NC_HAS_PARALLEL4, but that was only recently introduced, so
-# we will go with NC_HAS_PARALLEL.)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "netcdf_meta.h"],
-[[#if !NC_HAS_PARALLEL
-# error
-#endif]
-])], [have_netcdf_par=yes], [have_netcdf_par=no])
-AC_MSG_CHECKING([whether netCDF provides parallel I/O for netCDF/HDF5])
-AC_MSG_RESULT([${have_netcdf_par}])
-
-# Do we have szip?
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "netcdf_meta.h"],
-[[#if !NC_HAS_SZIP_WRITE
-# error
-#endif]
-])], [have_szip_write=yes], [have_szip_write=no])
-AC_MSG_CHECKING([whether netCDF provides szip write capability])
-AC_MSG_RESULT([${have_szip_write}])
-
-# Do we have parallel filter support? Parallel filters are required
-# for iotype NETCDF4P to use compression.
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "netcdf_meta.h"],
-[[#if !NC_HAS_PAR_FILTERS
-# error
-#endif]
-])], [have_par_filters=yes], [have_par_filters=no])
-AC_MSG_CHECKING([whether netCDF provides parallel filter support])
-AC_MSG_RESULT([${have_par_filters}])
-if test "x$have_par_filters" = xyes ; then
-   AC_DEFINE([HAVE_PAR_FILTERS], [1], [if true, netCDF-C supports filters with parallel I/O])
+if test "x$have_netcdf4" = xno; then
+   AC_MSG_ERROR([NetCDF-4 is required])
 fi
 
 # Is this version 4.7.2, which does not work?
@@ -263,6 +233,55 @@ AC_MSG_RESULT([${have_472}])
 if test "x$have_472" = xyes; then
    AC_MSG_ERROR([cannot build with netcdf-c-4.7.2, please upgrade your netCDF version.])
 fi
+
+# Do we have a parallel build of netCDF-4? (Really we should be
+# checking NC_HAS_PARALLEL4, but that was only recently introduced, so
+# we will go with NC_HAS_PARALLEL.)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "netcdf_meta.h"],
+[[#if !NC_HAS_PARALLEL
+# error
+#endif]
+])], [have_netcdf_par=yes], [have_netcdf_par=no])
+AC_MSG_CHECKING([whether netCDF provides parallel I/O for netCDF/HDF5])
+AC_MSG_RESULT([${have_netcdf_par}])
+AC_SUBST(HAS_NETCDF_PAR,[$have_netcdf_par])
+AM_CONDITIONAL(HAVE_NETCDF_PAR, [test "x$have_netcdf_par" = xyes])
+
+# Do we have szip?
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "netcdf_meta.h"],
+[[#if !NC_HAS_SZIP_WRITE
+# error
+#endif]
+])], [have_szip_write=yes], [have_szip_write=no])
+AC_MSG_CHECKING([whether netCDF provides szip write capability])
+AC_MSG_RESULT([${have_szip_write}])
+
+# Do we have parallel filter support?
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "netcdf_meta.h"],
+[[#if !NC_HAS_PAR_FILTERS
+# error
+#endif]
+])], [have_par_filters=yes], [have_par_filters=no])
+AC_MSG_CHECKING([whether netCDF provides parallel filter support])
+AC_MSG_RESULT([${have_par_filters}])
+if test "x$have_par_filters" = xyes ; then
+   AC_DEFINE([HAVE_PAR_FILTERS], [1], [if true, netCDF-C supports filters with parallel I/O])
+fi
+AC_SUBST(HAS_PAR_FILTERS,[$have_par_filters])
+
+# Does netcdf-c support multiple filters (version 4.8.0 or later).
+AC_MSG_CHECKING([if netCDF handles multiple filters])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+#include <netcdf_meta.h>
+#if !defined(NC_HAS_MULTIFILTERS) || NC_HAS_MUITIFILTERS == 0
+      choke me
+#endif]])], [have_multifilters=yes], [have_multifilters=no])
+if test "x$have_multifilters" = xyes; then
+   AC_DEFINE([HAVE_MULTIFILTERS], [1], [if true, netCDF-C supports multiple filters])
+fi
+AM_CONDITIONAL(HAVE_MULTIFILTERS, [test "x$have_multifilters" = xyes])
+AC_SUBST(HAS_MULTIFILTERS,[$have_multifilters])
+AC_MSG_RESULT([$have_multifilters])
 
 # Check for netCDF Fortran library.
 if test "x$enable_fortran" = xyes; then
@@ -320,20 +339,6 @@ AC_SUBST([CPPFLAGS])
 AC_SUBST([LDFLAGS])
 AC_SUBST([HDF5_PLUGIN_PATH])
 
-# Does netcdf-c support multiple filters (version 4.8.0 or later).
-AC_MSG_CHECKING([if netCDF handles multiple filters])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
-#include <netcdf_meta.h>
-#if !defined(NC_HAS_MULTIFILTERS) || NC_HAS_MUITIFILTERS == 0
-      choke me
-#endif]])], [have_multifilters=yes], [have_multifilters=no])
-if test "x$have_multifilters" = xyes; then
-   AC_DEFINE([ENABLE_MULTIFILTERS], [1], [Enable use of multiple filters])
-fi
-AM_CONDITIONAL(HAVE_MULTIFILTERS, [test "x$have_multifilters" = xyes])
-AC_SUBST(HAS_MULTIFILTERS,[$have_multifilters])
-AC_MSG_RESULT([$have_multifilters])
-
 # Args:
 # 1. ccr_meta.h variable
 # 2. conditional variable that is yes or no.
@@ -359,6 +364,8 @@ AX_SET_META([CCR_HAS_BITGROOM],[$enable_bitgroom],[yes])
 AC_SUBST(HAS_BZIP2,[$enable_bzip2])
 AX_SET_META([CCR_HAS_BZIP2],[$enable_bzip2],[yes])
 
+AX_SET_META([CCR_HAS_NETCDF_PAR],[$have_netcdf_par],[yes])
+AX_SET_META([CCR_HAS_PAR_FILTERS],[$have_par_filters],[yes])
 AX_SET_META([CCR_HAS_MULTIFILTERS],[$have_multifilters],[yes])
 
 # THis is the text summary and header file of how CCR was built.

--- a/configure.ac
+++ b/configure.ac
@@ -319,6 +319,38 @@ AC_SUBST([CFLAGS])
 AC_SUBST([CPPFLAGS])
 AC_SUBST([LDFLAGS])
 
+# Does netcdf-c support multiple filters (version 4.8.0 or later).
+AC_MSG_CHECKING([if netCDF handles multiple filters])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+#include <netcdf_meta.h>
+#if !defined(NC_HAS_MULTIFILTERS) || NC_HAS_MUITIFILTERS == 0
+      choke me
+#endif]])], [have_multifilters=yes], [have_multifilters=no])
+if test "x$have_multifilters" = xyes; then
+   AC_DEFINE([ENABLE_MULTIFILTERS], [1], [Enable use of multiple filters])
+fi
+AM_CONDITIONAL(HAVE_MULTIFILTERS, [test "x$have_multifilters" = xyes])
+AC_SUBST(HAS_MULTIFILTERS,[$have_multifilters])
+AC_MSG_RESULT([$have_multifilters])
+
+# Args:
+# 1. ccr_meta.h variable
+# 2. conditional variable that is yes or no.
+# 3. default condition
+#
+# example: AX_SET_META([CCR_HAS_NC2],[$ccr_build_v2],[]) # Because it checks for no.
+#          AX_SET_META([CCR_HAS_HDF4],[$enable_hdf4],[yes])
+AC_DEFUN([AX_SET_META],[
+  if [ test "x$2" = x$3 ]; then
+     AC_SUBST([$1]) $1=1
+  else
+     AC_SUBST([$1]) $1=0
+  fi
+])
+
+# Settings for libccr.settings and ccr_meta.h.
+AX_SET_META([CCR_HAS_MULTIFILTERS],[$have_multifilters],[yes])
+
 # THis is the text summary and header file of how CCR was built.
 AC_CONFIG_FILES([libccr.settings
                  include/ccr_meta.h

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 AC_PREREQ([2.59])
 
 # Initialize with name, version, and support email address.
-AC_INIT([ccr], [1.1.0], [])
+AC_INIT([ccr], [1.0.0-development], [])
 
 AM_INIT_AUTOMAKE([foreign dist-zip subdir-objects])
 
@@ -16,6 +16,45 @@ AC_CONFIG_MACRO_DIR([m4])
 # Set up libtool.
 LT_PREREQ([2.4])
 LT_INIT()
+
+# Components of the version.
+AC_SUBST([CCR_VERSION_MAJOR]) CCR_VERSION_MAJOR=1
+AC_SUBST([CCR_VERSION_MINOR]) CCR_VERSION_MINOR=0
+AC_SUBST([CCR_VERSION_PATCH]) CCR_VERSION_PATCH=0
+AC_SUBST([CCR_VERSION_NOTE]) CCR_VERSION_NOTE="-development"
+AC_SUBST([CCR_VERSION]) CCR_VERSION=$VERSION
+
+# Configuration Date
+if test "x$SOURCE_DATE_EPOCH" != "x" ; then
+    AC_SUBST([CONFIG_DATE]) CONFIG_DATE="`date -u -d "${SOURCE_DATE_EPOCH}"`"
+else
+    AC_SUBST([CONFIG_DATE]) CONFIG_DATE="`date`"
+fi
+
+# Prefer an empty CFLAGS variable instead of the default -g -O2. See:
+# http://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/C-Compiler.html#C-Compiler
+: ${CFLAGS=""}
+
+## Compiler with version information. This consists of the full path
+## name of the compiler and the reported version number.
+AC_SUBST([CC_VERSION])
+## Strip anything that looks like a flag off of $CC
+CC_NOFLAGS=`echo $CC | sed 's/ -.*//'`
+
+if `echo $CC_NOFLAGS | grep ^/ >/dev/null 2>&1`; then
+  CC_VERSION="$CC"
+else
+  CC_VERSION="$CC";
+  for x in `echo $PATH | sed -e 's/:/ /g'`; do
+    if test -x $x/$CC_NOFLAGS; then
+      CC_VERSION="$x/$CC"
+      break
+    fi
+  done
+fi
+if test -n "$cc_version_info"; then
+  CC_VERSION="$CC_VERSION ( $cc_version_info)"
+fi
 
 # Find the C compiler.
 AC_PROG_CC
@@ -272,6 +311,19 @@ AC_SUBST(CCR_FLIBS,[$CCR_FLIBS])
 AC_SUBST(BUILD_FORTRAN,[$enable_fortran])
 AC_CONFIG_FILES([ccr-config], [chmod 755 ccr-config])
 
+# Create output variables from various shell variables, for use in
+# generating libccr.settings.
+AC_SUBST([enable_shared])
+AC_SUBST([enable_static])
+AC_SUBST([CFLAGS])
+AC_SUBST([CPPFLAGS])
+AC_SUBST([LDFLAGS])
+
+# THis is the text summary and header file of how CCR was built.
+AC_CONFIG_FILES([libccr.settings
+                 include/ccr_meta.h
+		 ])
+		 
 # These files will be created when the configure script is run.
 AC_CONFIG_FILES([Makefile
 	src/Makefile
@@ -283,3 +335,5 @@ AC_CONFIG_FILES([Makefile
 	docs/Makefile
         ])
 AC_OUTPUT()
+
+cat libccr.settings

--- a/configure.ac
+++ b/configure.ac
@@ -318,6 +318,7 @@ AC_SUBST([enable_static])
 AC_SUBST([CFLAGS])
 AC_SUBST([CPPFLAGS])
 AC_SUBST([LDFLAGS])
+AC_SUBST([HDF5_PLUGIN_PATH])
 
 # Does netcdf-c support multiple filters (version 4.8.0 or later).
 AC_MSG_CHECKING([if netCDF handles multiple filters])
@@ -351,6 +352,12 @@ AC_DEFUN([AX_SET_META],[
 # Settings for libccr.settings and ccr_meta.h.
 AC_SUBST(HAS_LZ4,[$enable_lz4])
 AX_SET_META([CCR_HAS_LZ4],[$enable_lz4],[yes])
+AC_SUBST(HAS_ZSTD,[$enable_zstd])
+AX_SET_META([CCR_HAS_ZSTD],[$enable_zstd],[yes])
+AC_SUBST(HAS_BITGROOM,[$enable_bitgroom])
+AX_SET_META([CCR_HAS_BITGROOM],[$enable_bitgroom],[yes])
+AC_SUBST(HAS_BZIP2,[$enable_bzip2])
+AX_SET_META([CCR_HAS_BZIP2],[$enable_bzip2],[yes])
 
 AX_SET_META([CCR_HAS_MULTIFILTERS],[$have_multifilters],[yes])
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -3,6 +3,8 @@
 # Ed Hartnett 12/24/2019
 
 # Install these header files.
-include_HEADERS = ccr.h
+include_HEADERS = ccr.h ccr_meta.h
 
 noinst_HEADERS = ccr_test.h
+
+EXTRA_DIST = ccr_meta.h.in

--- a/include/ccr_meta.h.in
+++ b/include/ccr_meta.h.in
@@ -1,0 +1,24 @@
+/*! \file ccr_meta.h
+ *
+ * Meta information for libccr which can be used by other packages which
+ * depend on libccr.
+ *
+ * @author Ed Hartnett
+ * @date 12/10/2020
+ */
+
+#ifndef CCR_META_H
+#define CCR_META_H
+
+#define CCR_VERSION_MAJOR @CCR_VERSION_MAJOR@ /*!< CCR major version. */
+#define CCR_VERSION_MINOR @CCR_VERSION_MINOR@ /*!< CCR minor version. */
+#define CCR_VERSION_PATCH @CCR_VERSION_PATCH@ /*!< CCR patch version. */
+#define CCR_VERSION_NOTE  "@CCR_VERSION_NOTE@" /*!< CCR note. May be blank. */
+#define CCR_VERSION       "@CCR_VERSION@" /*!< CCR version string. */
+
+/* #define NC_HAS_SZIP      @NC_HAS_SZIP@ /\*!< szip support (HDF5 only) *\/ */
+/* #define NC_HAS_PARALLEL4 @NC_HAS_PARALLEL4@ /\*!< parallel IO support via HDF5 *\/ */
+/* #define NC_HAS_PAR_FILTERS @NC_HAS_PAR_FILTERS@ /\* Parallel I/O with filter support. *\/ */
+/* #define NC_HAS_MULTIFILTERS   @NC_HAS_MULTIFILTERS@ */
+
+#endif

--- a/include/ccr_meta.h.in
+++ b/include/ccr_meta.h.in
@@ -16,6 +16,7 @@
 #define CCR_VERSION_NOTE  "@CCR_VERSION_NOTE@" /*!< CCR note. May be blank. */
 #define CCR_VERSION       "@CCR_VERSION@" /*!< CCR version string. */
 
+#define NC_HAS_LZ4      @NC_HAS_LZ4@ /*!< LZ4 support. */
 #define CCR_HAS_MULTIFILTERS   @CCR_HAS_MULTIFILTERS@
 
 #endif

--- a/include/ccr_meta.h.in
+++ b/include/ccr_meta.h.in
@@ -16,9 +16,6 @@
 #define CCR_VERSION_NOTE  "@CCR_VERSION_NOTE@" /*!< CCR note. May be blank. */
 #define CCR_VERSION       "@CCR_VERSION@" /*!< CCR version string. */
 
-/* #define NC_HAS_SZIP      @NC_HAS_SZIP@ /\*!< szip support (HDF5 only) *\/ */
-/* #define NC_HAS_PARALLEL4 @NC_HAS_PARALLEL4@ /\*!< parallel IO support via HDF5 *\/ */
-/* #define NC_HAS_PAR_FILTERS @NC_HAS_PAR_FILTERS@ /\* Parallel I/O with filter support. *\/ */
-/* #define NC_HAS_MULTIFILTERS   @NC_HAS_MULTIFILTERS@ */
+#define CCR_HAS_MULTIFILTERS   @CCR_HAS_MULTIFILTERS@
 
 #endif

--- a/include/ccr_meta.h.in
+++ b/include/ccr_meta.h.in
@@ -1,4 +1,4 @@
-/*! \file ccr_meta.h
+/*! @file
  *
  * Meta information for libccr which can be used by other packages which
  * depend on libccr.
@@ -16,7 +16,10 @@
 #define CCR_VERSION_NOTE  "@CCR_VERSION_NOTE@" /*!< CCR note. May be blank. */
 #define CCR_VERSION       "@CCR_VERSION@" /*!< CCR version string. */
 
-#define NC_HAS_LZ4      @NC_HAS_LZ4@ /*!< LZ4 support. */
-#define CCR_HAS_MULTIFILTERS   @CCR_HAS_MULTIFILTERS@
+#define CCR_HAS_BZIP2          @CCR_HAS_BZIP2@ /*!< BZIP2 support. */
+#define CCR_HAS_ZSTD           @CCR_HAS_ZSTD@ /*!< ZSTD support. */
+#define CCR_HAS_LZ4            @CCR_HAS_LZ4@ /*!< LZ4 support. */
+#define CCR_HAS_BITGROOM       @CCR_HAS_BITGROOM@ /*!< BITGROOM support. */
+#define CCR_HAS_MULTIFILTERS   @CCR_HAS_MULTIFILTERS@ /*!< Multiple filter support. */
 
 #endif

--- a/include/ccr_meta.h.in
+++ b/include/ccr_meta.h.in
@@ -20,6 +20,8 @@
 #define CCR_HAS_ZSTD           @CCR_HAS_ZSTD@ /*!< ZSTD support. */
 #define CCR_HAS_LZ4            @CCR_HAS_LZ4@ /*!< LZ4 support. */
 #define CCR_HAS_BITGROOM       @CCR_HAS_BITGROOM@ /*!< BITGROOM support. */
+#define CCR_HAS_NETCDF_PAR     @CCR_HAS_NETCDF_PAR@ /*!< Parallel I/O support. */
+#define CCR_HAS_PAR_FILTERS    @CCR_HAS_PAR_FILTERS@ /*!< Parallel I/O filter support. */
 #define CCR_HAS_MULTIFILTERS   @CCR_HAS_MULTIFILTERS@ /*!< Multiple filter support. */
 
 #endif

--- a/libccr.settings.in
+++ b/libccr.settings.in
@@ -27,4 +27,6 @@ BZIP2 Support:		@HAS_BZIP2@
 LZ4 Support:		@HAS_LZ4@
 BITGROOM Support:	@HAS_BITGROOM@
 ZSTD Support:		@HAS_ZSTD@
+Parallel I/O Support:	@HAS_NETCDF_PAR@
+Parallel I/O Filters:	@HAS_PAR_FILTERS@
 Multi-Filter Support:	@HAS_MULTIFILTERS@

--- a/libccr.settings.in
+++ b/libccr.settings.in
@@ -22,4 +22,5 @@ Extra libraries:	@LIBS@
 # Features
 --------
 
+LZ4 Support:		@HAS_LZ4@
 Multi-Filter Support:	@HAS_MULTIFILTERS@

--- a/libccr.settings.in
+++ b/libccr.settings.in
@@ -1,0 +1,24 @@
+# CCR Configuration Summary
+==============================
+
+# General
+-------
+CCR Version:		@PACKAGE_VERSION@
+Configured On:		@CONFIG_DATE@
+Host System:		@host_cpu@-@host_vendor@-@host_os@
+Build Directory: 	@abs_top_builddir@
+Install Prefix:         @prefix@
+
+# Compiling Options
+-----------------
+C Compiler:		@CC_VERSION@
+CFLAGS:			@CFLAGS@
+CPPFLAGS:		@CPPFLAGS@
+LDFLAGS:		@LDFLAGS@
+Shared Library:		@enable_shared@
+Static Library:		@enable_static@
+Extra libraries:	@LIBS@
+
+# Features
+--------
+

--- a/libccr.settings.in
+++ b/libccr.settings.in
@@ -22,3 +22,4 @@ Extra libraries:	@LIBS@
 # Features
 --------
 
+Multi-Filter Support:	@HAS_MULTIFILTERS@

--- a/libccr.settings.in
+++ b/libccr.settings.in
@@ -18,9 +18,13 @@ LDFLAGS:		@LDFLAGS@
 Shared Library:		@enable_shared@
 Static Library:		@enable_static@
 Extra libraries:	@LIBS@
+HDF5_PLUGIN_PATH:	@HDF5_PLUGIN_PATH@
 
 # Features
 --------
 
+BZIP2 Support:		@HAS_BZIP2@
 LZ4 Support:		@HAS_LZ4@
+BITGROOM Support:	@HAS_BITGROOM@
+ZSTD Support:		@HAS_ZSTD@
 Multi-Filter Support:	@HAS_MULTIFILTERS@


### PR DESCRIPTION
Fixes #109 
Part of #85 
Part of #33 

Add a build summary and a ccr_meta.h output file. THe build summary looks like this:

```
# CCR Configuration Summary
==============================

# General
-------
CCR Version:		1.0.0-development
Configured On:		Thu Dec 10 10:52:02 MST 2020
Host System:		x86_64-pc-linux-gnu
Build Directory: 	/home/ed/ccr
Install Prefix:         /usr/local

# Compiling Options
-----------------
C Compiler:		/usr/bin/gcc
CFLAGS:			-g -O2
CPPFLAGS:		-I/usr/local/hdf5-1.10.6/include -I/usr/local/netcdf-fortran-4.5.3_netcdf-c-4.7.4/include -I/usr/local/netcdf-c-4.7.4_hdf5-1.10.6/include
LDFLAGS:		-L/usr/local/hdf5-1.10.6/lib -L/usr/local/netcdf-fortran-4.5.3_netcdf-c-4.7.4/lib -L/usr/local/netcdf-c-4.7.4_hdf5-1.10.6/lib
Shared Library:		yes
Static Library:		yes
Extra libraries:	-ldl -lhdf5_hl -lhdf5 -lnetcdff -lnetcdf -lm 
HDF5_PLUGIN_PATH:	.

# Features
--------

BZIP2 Support:		yes
LZ4 Support:		no
BITGROOM Support:	yes
ZSTD Support:		yes
Parallel I/O Support:	no
Parallel I/O Filters:	yes
Multi-Filter Support:	no
```

The ccr_meta.h file looks like this:

```
/*! @file
 *
 * Meta information for libccr which can be used by other packages which
 * depend on libccr.
 *
 * @author Ed Hartnett
 * @date 12/10/2020
 */

#ifndef CCR_META_H
#define CCR_META_H

#define CCR_VERSION_MAJOR 1 /*!< CCR major version. */
#define CCR_VERSION_MINOR 0 /*!< CCR minor version. */
#define CCR_VERSION_PATCH 0 /*!< CCR patch version. */
#define CCR_VERSION_NOTE  "-development" /*!< CCR note. May be blank. */
#define CCR_VERSION       "1.0.0-development" /*!< CCR version string. */

#define CCR_HAS_BZIP2          1 /*!< BZIP2 support. */
#define CCR_HAS_ZSTD           1 /*!< ZSTD support. */
#define CCR_HAS_LZ4            0 /*!< LZ4 support. */
#define CCR_HAS_BITGROOM       1 /*!< BITGROOM support. */
#define CCR_HAS_NETCDF_PAR     0 /*!< Parallel I/O support. */
#define CCR_HAS_PAR_FILTERS    1 /*!< Parallel I/O filter support. */
#define CCR_HAS_MULTIFILTERS   0 /*!< Multiple filter support. */

#endif
```

Also define appropriate automake and c-preprocessor symbols to detect parallel I/O and multifilters.