### PR TITLE
Clean up of parallel I/O test for zstandard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -297,7 +297,7 @@ AC_SUBST(HAS_PAR_FILTERS,[$have_par_filters])
 AC_MSG_CHECKING([if netCDF handles multiple filters])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
 #include <netcdf_meta.h>
-#if !defined(NC_HAS_MULTIFILTERS) || NC_HAS_MUITIFILTERS == 0
+#if !defined(NC_HAS_MULTIFILTERS) || NC_HAS_MULTIFILTERS == 0
       choke me
 #endif]])], [have_multifilters=yes], [have_multifilters=no])
 if test "x$have_multifilters" = xyes; then

--- a/test/tst_par.c
+++ b/test/tst_par.c
@@ -11,7 +11,7 @@
 #include <mpi.h>
 #include <stdio.h>
 
-#define FILE "tst_par_zlib.nc"
+#define TEST "tst_par"
 #define NDIMS 3
 #define DIMSIZE 24
 #define QTR_DATA (DIMSIZE * DIMSIZE / 4)
@@ -44,7 +44,7 @@ main(int argc, char **argv)
 
 #ifdef BUILD_ZSTD
     if (mpi_rank == 0)
-	printf("*** testing simple write with zlib...");
+	printf("*** testing simple write with zstd...");
     {
 	/* Create phony data. We're going to write a 24x24 array of ints,
 	   in 4 sets of 144. */
@@ -54,7 +54,7 @@ main(int argc, char **argv)
 	/* Create a parallel netcdf-4 file. */
 	/*nc_set_log_level(3);*/
 	/* sprintf(file_name, "%s/%s", TEMP_LARGE, FILE); */
-	sprintf(file_name, "%s", FILE);
+	sprintf(file_name, "%s_zstd.nc", TEST);
 	if ((res = nc_create_par(file_name, NC_NETCDF4, comm, info, &ncid))) ERR;
 
 	/* Create three dimensions. */

--- a/test_h5/tst_h_bzip2.c
+++ b/test_h5/tst_h_bzip2.c
@@ -55,7 +55,7 @@ main()
               NULL,                       /* The "set local" callback     */
               (H5Z_func_t)H5Z_filter_bzip2,         /* The actual filter function   */
           }};
-      char plugin_path[MAX_LEN + 1];
+      /* char plugin_path[MAX_LEN + 1]; */
 
       /* Create some data to write. */
       for (x = 0; x < NX; x++)


### PR DESCRIPTION
Fixes #85

Test works. Data using zstd compression are written from 4 tasks to a file. Then the data are read by the 4 tasks and compared to input.

