### PR TITLE
Move var declarations from ccr_test.h, also adding more performance testing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -336,6 +336,7 @@ AC_SEARCH_LIBS([dlopen], [dl dld], [], [])
 # Configure the test running scripts.
 AC_CONFIG_FILES([test/run_tests.sh], [chmod ugo+x test/run_tests.sh])
 AC_CONFIG_FILES([test/run_par_tests.sh], [chmod ugo+x test/run_par_tests.sh])
+AC_CONFIG_FILES([test/run_benchmarks.sh], [chmod ugo+x test/run_benchmarks.sh])
 AC_CONFIG_FILES([ftest/run_tests.sh], [chmod ugo+x ftest/run_tests.sh])
 AC_CONFIG_FILES([test_h5/run_tests.sh], [chmod ugo+x test_h5/run_tests.sh])
 

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,17 @@ test "x$enable_fortran" = xyes || enable_fortran=no
 AC_MSG_RESULT([$enable_fortran])
 AM_CONDITIONAL(BUILD_FORTRAN, [test "x$enable_fortran" = xyes])
 
+# Does the user want to run benchmarks?
+AC_MSG_CHECKING([whether benchmarks should be run])
+AC_ARG_ENABLE([benchmarks],
+              [AS_HELP_STRING([--enable-benchmarks],
+                              [Run benchmarks. This will cause sample data files from the Unidata ftp
+                              site to be fetched. The benchmarks are a bunch of extra tests, which
+                              are timed. We use these tests to measure performance. This is slow.])])
+test "x$enable_benchmarks" = xyes || enable_benchmarks=no
+AC_MSG_RESULT($enable_benchmarks)
+AM_CONDITIONAL(BUILD_BENCHMARKS, [test x$enable_benchmarks = xyes])
+
 # Does the user want to build documentation?
 AC_MSG_CHECKING([whether documentation should be build (requires doxygen)])
 AC_ARG_ENABLE([docs],
@@ -388,6 +399,8 @@ AC_SUBST(HAS_BITGROOM,[$enable_bitgroom])
 AX_SET_META([CCR_HAS_BITGROOM],[$enable_bitgroom],[yes])
 AC_SUBST(HAS_BZIP2,[$enable_bzip2])
 AX_SET_META([CCR_HAS_BZIP2],[$enable_bzip2],[yes])
+AC_SUBST(HAS_BENCHMARKS,[$enable_benchmarks])
+AX_SET_META([CCR_HAS_BENCHMARKS],[$enable_benchmarks],[yes])
 
 AX_SET_META([CCR_HAS_NETCDF_PAR],[$have_netcdf_par],[yes])
 AX_SET_META([CCR_HAS_PAR_FILTERS],[$have_par_filters],[yes])

--- a/include/ccr_meta.h.in
+++ b/include/ccr_meta.h.in
@@ -23,5 +23,6 @@
 #define CCR_HAS_NETCDF_PAR     @CCR_HAS_NETCDF_PAR@ /*!< Parallel I/O support. */
 #define CCR_HAS_PAR_FILTERS    @CCR_HAS_PAR_FILTERS@ /*!< Parallel I/O filter support. */
 #define CCR_HAS_MULTIFILTERS   @CCR_HAS_MULTIFILTERS@ /*!< Multiple filter support. */
+#define CCR_HAS_BENCHMARKS     @CCR_HAS_BENCHMARKS@ /*!< Benchmarks built. */
 
 #endif

--- a/include/ccr_test.h
+++ b/include/ccr_test.h
@@ -13,10 +13,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-/* Err is used to keep track of errors within each set of tests,
- * total_err is the number of errors in the entire test program, which
- * generally cosists of several sets of tests. */
-static int total_err = 0, err = 0;
+#define MILLION 1000000
 
 /* This macro prints an error message with line number and name of
  * test program. */

--- a/libccr.settings.in
+++ b/libccr.settings.in
@@ -30,3 +30,4 @@ ZSTD Support:		@HAS_ZSTD@
 Parallel I/O Support:	@HAS_NETCDF_PAR@
 Parallel I/O Filters:	@HAS_PAR_FILTERS@
 Multi-Filter Support:	@HAS_MULTIFILTERS@
+Benchmarks:  		@HAS_BENCHMARKS@

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,6 +29,7 @@ endif
 
 # Build the performance test.
 check_PROGRAMS += tst_perf
+tst_perf_SOURCES = tst_perf.c tst_utils.c
 
 # Run all the appropriate tests in this script.
 TESTS = run_tests.sh
@@ -42,6 +43,7 @@ endif
 # Build benchmark program if desired.
 if BUILD_BENCHMARKS
 check_PROGRAMS += tst_benchmark
+tst_benchmark_SOURCES = tst_benchmark.c tst_utils.c
 TESTS += run_benchmarks.sh
 endif
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,11 +30,6 @@ endif
 # Build the performance test.
 check_PROGRAMS += tst_perf
 
-# Build benchmark program if desired.
-if BUILD_BENCHMARKS
-check_PROGRAMS += tst_benchmark
-endif
-
 # Run all the appropriate tests in this script.
 TESTS = run_tests.sh
 
@@ -44,9 +39,15 @@ check_PROGRAMS += tst_par
 TESTS += run_par_tests.sh
 endif
 
+# Build benchmark program if desired.
+if BUILD_BENCHMARKS
+check_PROGRAMS += tst_benchmark
+TESTS += run_benchmarks.sh
+endif
+
 # Delete files created in testing.
 CLEANFILES = tst_*.nc
 
-EXTRA_DIST = run_tests.sh.in run_par_tests.sh.in
+EXTRA_DIST = run_tests.sh.in run_par_tests.sh.in run_benchmarks.sh.in
 
-DISTCLEAN = run_tests.sh run_par_tests.sh
+DISTCLEAN = run_tests.sh run_par_tests.sh run_benchmarks.sh

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,6 +30,11 @@ endif
 # Build the performance test.
 check_PROGRAMS += tst_perf
 
+# Build benchmark program if desired.
+if BUILD_BENCHMARKS
+check_PROGRAMS += tst_benchmark
+endif
+
 # Run all the appropriate tests in this script.
 TESTS = run_tests.sh
 

--- a/test/run_benchmarks.sh.in
+++ b/test/run_benchmarks.sh.in
@@ -1,0 +1,16 @@
+# This script runs the benchmarks in the CCR project.
+#
+# Ed Hartnett 12/14/20
+set -x
+set -e
+
+# If zstandard was built, add it to plugin path.
+if test "@BUILD_ZSTD@" = "yes"; then
+    export HDF5_PLUGIN_PATH="../hdf5_plugins/ZSTANDARD/src/.libs:$HDF5_PLUGIN_PATH"
+fi
+
+./tst_benchmark
+
+
+
+

--- a/test/tst_benchmark.c
+++ b/test/tst_benchmark.c
@@ -1,0 +1,211 @@
+/* This is part of the CCR package. Copyright 2020.
+
+   Test performance.
+
+   Ed Hartnett 12/14/20
+*/
+
+#include "config.h"
+#include "ccr.h"
+#include "ccr_test.h"
+#include <hdf5.h>
+#include <H5DSpublic.h>
+#include <netcdf.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h> /* Extra high precision time info. */
+#include <sys/stat.h> /* To get file sizes. */
+
+#define FILE_NAME "tst_benchmark.nc"
+#define TEST "tst_benchmark"
+#define STR_LEN 255
+#define MAX_LEN 1024
+#define X_NAME "X"
+#define Y_NAME "Y"
+#define NDIM2 2
+#define NDIM3 3
+#define VAR_NAME "Midnight_Special"
+#define VAR_NAME_2 "Bad_Moon_Rising"
+#define VOICE_OF_RAGE "VOICE_OF_RAGE"
+#define VOICE_OF_RUIN "VOICE_OF_RUIN"
+#define EARTHQUAKES_AND_LIGHTNING "EARTHQUAKES_AND_LIGHTNING"
+
+#define MILLION 1000000
+#define NFILE 18 /* This must be an even number. */
+#define MAX_COMPRESSION_STR 4
+
+#define NX_BIG 1000
+#define NY_BIG 1000
+/* Restore these larger values to run the big file tests. */
+#define NX_REALLY_BIG 1000
+#define NY_REALLY_BIG 5000
+/* #define NX_REALLY_BIG 100 */
+/* #define NY_REALLY_BIG 50 */
+#define NUM_REC 5
+
+#define MIN_ZSTD 0
+#define MAX_ZSTD 9
+#define MIN_ZLIB 1
+
+/** Subtract the `struct timeval' values X and Y, storing the result in
+   RESULT.  Return 1 if the difference is negative, otherwise 0.  This
+   function from the GNU documentation. */
+int
+nc4_timeval_subtract (result, x, y)
+   struct timeval *result, *x, *y;
+{
+   /* Perform the carry for the later subtraction by updating Y. */
+   if (x->tv_usec < y->tv_usec) {
+      int nsec = (y->tv_usec - x->tv_usec) / MILLION + 1;
+      y->tv_usec -= MILLION * nsec;
+      y->tv_sec += nsec;
+   }
+   if (x->tv_usec - y->tv_usec > MILLION) {
+      int nsec = (x->tv_usec - y->tv_usec) / MILLION;
+      y->tv_usec += MILLION * nsec;
+      y->tv_sec -= nsec;
+   }
+
+   /* Compute the time remaining to wait.
+      `tv_usec' is certainly positive. */
+   result->tv_sec = x->tv_sec - y->tv_sec;
+   result->tv_usec = x->tv_usec - y->tv_usec;
+
+   /* Return 1 if result is negative. */
+   return x->tv_sec < y->tv_sec;
+}
+    
+int
+main()
+{
+    struct stat st;
+    
+    printf("\n*** Checking Performance of filters.\n");
+#ifdef BUILD_ZSTD    
+    printf("*** Checking Zstandard vs. zlib performance on large float data set...");
+    printf("\ncompression, level, write time (s), file size (MB)\n");
+    {
+        float *data_out;
+        size_t x;
+	int f;
+	int level = MIN_ZSTD;
+	char compression[MAX_COMPRESSION_STR + 1];
+	float a = 5.0;
+    
+        if (!(data_out = malloc(NX_REALLY_BIG * NY_REALLY_BIG * sizeof(int)))) ERR;
+
+	/* We will write NFILE compressed file, and 1 uncompressed
+	 * file. Half the compressed files will be zstd, half zlib. */
+	for (f = 0; f < NFILE + 1; f++)
+	{
+	    char file_name[STR_LEN + 1];
+	    float *data_in;
+	    int ncid;
+	    int dimid[NDIM3];
+	    int varid;
+	    size_t start[NDIM3] = {0, 0, 0};
+	    size_t count[NDIM3] = {1, NX_REALLY_BIG, NY_REALLY_BIG};
+	    struct timeval start_time, end_time, diff_time;
+	    int meta_write_us;
+	    int increment = 1;
+	    
+	    if (!(data_in = malloc(NX_REALLY_BIG * NY_REALLY_BIG * sizeof(float)))) ERR;
+
+	    if (f)
+		strcpy(compression, (f < NFILE / 2 + 1) ? "zstd" : "zlib");
+
+	    if (f)
+		sprintf(file_name, "%s_%s_really_big_%d.nc", TEST, compression, level);
+	    else
+		sprintf(file_name, "%s_uncompressed_really_big.nc", TEST);
+
+	    /* Create file. */
+	    if (gettimeofday(&start_time, NULL)) ERR;
+
+	    if (nc_create(file_name, NC_CLOBBER|NC_NETCDF4, &ncid)) ERR;
+	    if (nc_def_dim(ncid, EARTHQUAKES_AND_LIGHTNING, NC_UNLIMITED, &dimid[0])) ERR;
+	    if (nc_def_dim(ncid, VOICE_OF_RAGE, NX_REALLY_BIG, &dimid[1])) ERR;
+	    if (nc_def_dim(ncid, VOICE_OF_RUIN, NY_REALLY_BIG, &dimid[2])) ERR;
+	    if (nc_def_var(ncid, VAR_NAME_2, NC_FLOAT, NDIM3, dimid, &varid)) ERR;
+	    if (f)
+	    {
+		if (f == NFILE / 2 + 1)
+		    level = MIN_ZLIB;
+		if (f < NFILE / 2 + 1)
+		{
+		    if (nc_def_var_zstandard(ncid, varid, level)) ERR;
+		    increment = 2;
+		}
+		else
+		{
+		    if (nc_def_var_deflate(ncid, varid, 0, 1, level)) ERR;
+		    increment = 1;
+		}
+	    }
+
+	    /* Write data records. */
+	    for (start[0] = 0; start[0] < NUM_REC; start[0]++)
+	    {
+		/* Create a new record to write. */
+		for (x = 0; x < NX_REALLY_BIG * NY_REALLY_BIG; x++)
+		{
+		    data_out[x] = ((float)rand()/(float)(RAND_MAX)) * a;
+		    /* data_out[x] = x + 1.; */
+		}
+		
+		if (nc_put_vara_float(ncid, varid, start, count, data_out)) ERR;
+	    }
+	    
+	    if (nc_close(ncid)) ERR;
+	    if (gettimeofday(&end_time, NULL)) ERR;
+	    if (nc4_timeval_subtract(&diff_time, &end_time, &start_time)) ERR;
+	    meta_write_us = (int)diff_time.tv_sec * MILLION + (int)diff_time.tv_usec;
+	    stat(file_name, &st);
+	    printf("%s, %d, %.2f, %.2f\n", (f ? compression : "none"), level, (float)meta_write_us/MILLION,
+		   (float)st.st_size/MILLION);
+	    
+	    /* /\* Check file. *\/ */
+	    /* { */
+	    /* 	int ncid; */
+	    /* 	int varid = 0; */
+	    /* 	int level_in, zstandard; */
+		
+	    /* 	if (nc_open(file_name, NC_NOWRITE, &ncid)) ERR; */
+	    /* 	if (nc_inq_var_zstandard(ncid, varid, &zstandard, &level_in)) ERR; */
+	    /* 	if (f) */
+	    /* 	{ */
+	    /* 	    if (f < NFILE / 2 + 1) */
+	    /* 	    { */
+	    /* 		if (!zstandard) ERR; */
+	    /* 	    } */
+	    /* 	    else */
+	    /* 	    { */
+	    /* 	    } */
+	    /* 	} */
+	    /* 	else */
+	    /* 	{ */
+	    /* 	    if (zstandard) ERR; */
+	    /* 	} */
+	    /* 	for (start[0] = 0; start[0] < NUM_REC; start[0]++) */
+	    /* 	{ */
+	    /* 	    if (nc_get_vara_float(ncid, varid, start, count, data_in)) ERR; */
+	    /* 	    for (x = 0; x < NX_REALLY_BIG * NY_REALLY_BIG; x++) */
+	    /* 		if (data_in[x] != x + 1.) */
+	    /* 		{ */
+	    /* 		    printf("data_out[%ld] %g data_in[%ld] %g\n", x, data_out[x], x, data_in[x]); */
+	    /* 		    ERR; */
+	    /* 		} */
+	    /* 	} */
+	    /* 	if (nc_close(ncid)) ERR; */
+	    /* } */
+
+	    level += increment;
+	    free(data_in);
+	} /* next file */
+        free(data_out);
+    }
+    SUMMARIZE_ERR;
+#endif /* BUILD_ZSTD */
+    FINAL_RESULTS;
+}

--- a/test/tst_bitgroom.c
+++ b/test/tst_bitgroom.c
@@ -29,6 +29,11 @@
 #define NX_BIG 100
 #define NY_BIG 100
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 int
 main()
 {

--- a/test/tst_bzip2.c
+++ b/test/tst_bzip2.c
@@ -31,6 +31,11 @@
 #define DEFLATE_LEVEL 3
 #define SIMPLE_VAR_NAME "data"
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 int
 main()
 {

--- a/test/tst_lz4.c
+++ b/test/tst_lz4.c
@@ -34,6 +34,11 @@
 #define NX_BIG 100
 #define NY_BIG 100
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 int
 main()
 {

--- a/test/tst_par.c
+++ b/test/tst_par.c
@@ -18,6 +18,11 @@
 #define NUM_PROC 4
 #define NUM_SLABS 10
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 int
 main(int argc, char **argv)
 {

--- a/test/tst_perf.c
+++ b/test/tst_perf.c
@@ -31,7 +31,6 @@
 #define VOICE_OF_RUIN "VOICE_OF_RUIN"
 #define EARTHQUAKES_AND_LIGHTNING "EARTHQUAKES_AND_LIGHTNING"
 
-#define MILLION 1000000
 #define NFILE 18 /* This must be an even number. */
 #define MAX_COMPRESSION_STR 4
 
@@ -48,34 +47,15 @@
 #define MAX_ZSTD 9
 #define MIN_ZLIB 1
 
-/** Subtract the `struct timeval' values X and Y, storing the result in
-   RESULT.  Return 1 if the difference is negative, otherwise 0.  This
-   function from the GNU documentation. */
-int
-nc4_timeval_subtract (result, x, y)
-   struct timeval *result, *x, *y;
-{
-   /* Perform the carry for the later subtraction by updating Y. */
-   if (x->tv_usec < y->tv_usec) {
-      int nsec = (y->tv_usec - x->tv_usec) / MILLION + 1;
-      y->tv_usec -= MILLION * nsec;
-      y->tv_sec += nsec;
-   }
-   if (x->tv_usec - y->tv_usec > MILLION) {
-      int nsec = (x->tv_usec - y->tv_usec) / MILLION;
-      y->tv_usec += MILLION * nsec;
-      y->tv_sec -= nsec;
-   }
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
 
-   /* Compute the time remaining to wait.
-      `tv_usec' is certainly positive. */
-   result->tv_sec = x->tv_sec - y->tv_sec;
-   result->tv_usec = x->tv_usec - y->tv_usec;
+/* Prototype from tst_utils.c. */
+int nc4_timeval_subtract(struct timeval *result, struct timeval *x,
+                         struct timeval *y);
 
-   /* Return 1 if result is negative. */
-   return x->tv_sec < y->tv_sec;
-}
-    
 int
 main()
 {

--- a/test/tst_utils.c
+++ b/test/tst_utils.c
@@ -1,0 +1,45 @@
+/*! \file Utility functions for tests.
+
+\internal
+Copyright 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,
+2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014,
+2015, 2016, 2017, 2018
+University Corporation for Atmospheric Research/Unidata.
+
+See \ref copyright file for more info.
+
+
+*/
+
+#include "config.h"
+#include "ccr_test.h"
+#include <time.h>
+#include <sys/time.h>
+
+/** Subtract the `struct timeval' values X and Y, storing the result in
+   RESULT.  Return 1 if the difference is negative, otherwise 0.  This
+   function from the GNU documentation. */
+int
+nc4_timeval_subtract (result, x, y)
+   struct timeval *result, *x, *y;
+{
+   /* Perform the carry for the later subtraction by updating Y. */
+   if (x->tv_usec < y->tv_usec) {
+      int nsec = (y->tv_usec - x->tv_usec) / MILLION + 1;
+      y->tv_usec -= MILLION * nsec;
+      y->tv_sec += nsec;
+   }
+   if (x->tv_usec - y->tv_usec > MILLION) {
+      int nsec = (x->tv_usec - y->tv_usec) / MILLION;
+      y->tv_usec += MILLION * nsec;
+      y->tv_sec -= nsec;
+   }
+
+   /* Compute the time remaining to wait.
+      `tv_usec' is certainly positive. */
+   result->tv_sec = x->tv_sec - y->tv_sec;
+   result->tv_usec = x->tv_usec - y->tv_usec;
+
+   /* Return 1 if result is negative. */
+   return x->tv_sec < y->tv_sec;
+}

--- a/test/tst_zstandard.c
+++ b/test/tst_zstandard.c
@@ -34,6 +34,11 @@
 #define NX_BIG 100
 #define NY_BIG 100
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 int
 main()
 {

--- a/test_h5/tst_h_bitgroom.c
+++ b/test_h5/tst_h_bitgroom.c
@@ -11,6 +11,11 @@
 #include <hdf5.h>
 #include <H5DSpublic.h>
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 #define FILE_NAME "tst_h_bitgroom.h5"
 #define STR_LEN 255
 #define MAX_LEN 1024

--- a/test_h5/tst_h_bzip2.c
+++ b/test_h5/tst_h_bzip2.c
@@ -12,6 +12,11 @@
 #include <hdf5.h>
 #include <H5DSpublic.h>
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 #define FILE_NAME "tst_h_bzip2.h5"
 #define STR_LEN 255
 #define MAX_LEN 1024

--- a/test_h5/tst_h_lz4.c
+++ b/test_h5/tst_h_lz4.c
@@ -16,6 +16,11 @@
 #define STR_LEN 255
 #define MAX_LEN 1024
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
                       const unsigned int cd_values[], size_t nbytes,
                       size_t *buf_size, void **buf);

--- a/test_h5/tst_h_zstandard.c
+++ b/test_h5/tst_h_zstandard.c
@@ -10,6 +10,11 @@
 #include <hdf5.h>
 #include <H5DSpublic.h>
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 #define FILE_NAME "tst_h_zstandard.h5"
 #define STR_LEN 255
 #define MAX_LEN 1024

--- a/test_h5/tst_lz4_size.c
+++ b/test_h5/tst_lz4_size.c
@@ -22,6 +22,11 @@
 #define NFILE 2
 #define MAX_NAME 80
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
                       const unsigned int cd_values[], size_t nbytes,
                       size_t *buf_size, void **buf);

--- a/test_h5/tst_zstandard_size.c
+++ b/test_h5/tst_zstandard_size.c
@@ -22,6 +22,11 @@
 #define NFILE 2
 #define MAX_NAME 80
 
+/* Err is used to keep track of errors within each set of tests,
+ * total_err is the number of errors in the entire test program, which
+ * generally cosists of several sets of tests. */
+static int total_err = 0, err = 0;
+
 size_t H5Z_filter_zstandard(unsigned int flags, size_t cd_nelmts,
                       const unsigned int cd_values[], size_t nbytes,
                       size_t *buf_size, void **buf);


### PR DESCRIPTION
Fixes #119 

Removed var declarations from ccr_test.h. Also moved timing function into new file test/tst_utils.c.

More performance testing.

Part of #105 
Part of #84