### PR TITLE
updated README and documentation for version 1.1.0, removed LZ4 functions from C and Fortran

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ added nc_def_var_filter() method (in version 4.7.3 and later).
 Additional filters are available, and support additional compression
 methods.
 
-Version 1.0 of the CCR supports:
+Version 1.1.0 of the CCR supports:
 * BZIP2 compression
-* LZ4 compression
+* Zstandard compression
+* BITGROOM pre-compression
 
 For full documentation see https://ccr.github.io/ccr/.
 
@@ -37,11 +38,6 @@ Zstandard | https://facebook.github.io/zstd/          | optional
 
 Codec     |  Environment | Install Command
 --------- |------------- | ---------------
-LZ4       |  CentOS      | sudo yum install lz4-devel
-LZ4       |  Conda       | conda install lz4
-LZ4       |  Debian      | sudo aptitude install liblz4-dev
-LZ4       |  Fedora      | sudo dnf install lz4-devel
-LZ4       |  MacPorts    | sudo port install lz4
 Zstandard |  CentOS      | sudo yum install libzstd-devel
 Zstandard |  Conda       | conda install zstd
 Zstandard |  Debian      | sudo aptitude install libzstd1-dev
@@ -50,22 +46,15 @@ Zstandard |  MacPorts    | sudo port install zstd
 
 ## Autotools Build
 
-Clone or download the CCR source code and run `autoreconf` to install
-some necessary build tools (this need be done only once).
-To build, run the `configure` script. The `configure` script will
-try to locate all the necessary dependencies. Use the `CPPFLAGS` and
-`LDFLAGS` environment variables to specify the locations of include and
-library files for the third-party libraries.
+Download the CCR release and unpack it. Run configure and make.
 
 Example:
 <pre>
-# Execute autoreconf once after downloading/cloning CCR:
-autoreconf -i
 # Set your environment as necessary and (re-)configure as necessary:
 export CFLAGS='-g -Wall'
 export CPPFLAGS='-I/usr/local/hdf5-1.10.6_mpich/include -I/usr/local/netcdf-c-4.7.4_hdf5-1.10.6_szip_mpich/include'
 export LDFLAGS='-L/usr/local/hdf5-1.10.6_mpich/lib -L/usr/local/netcdf-c-4.7.4_hdf5-1.10.6_szip_mpich/lib'
-./configure --disable-lz4 --disable-zstd 
+./configure  
 </pre>
 
 Build the CCR code with `make`, install the CCR library with

--- a/fsrc/ccr.F90
+++ b/fsrc/ccr.F90
@@ -24,22 +24,22 @@ module ccr
      end function nc_inq_var_bzip2
   end interface
 
-  !> Interface to C function to set LZ4 compression.
-  interface
-     function nc_def_var_lz4(ncid, varid, level) bind(c)
-       use iso_c_binding
-       integer(C_INT), value :: ncid, varid, level
-     end function nc_def_var_lz4
-  end interface
+  ! !> Interface to C function to set LZ4 compression.
+  ! interface
+  !    function nc_def_var_lz4(ncid, varid, level) bind(c)
+  !      use iso_c_binding
+  !      integer(C_INT), value :: ncid, varid, level
+  !    end function nc_def_var_lz4
+  ! end interface
 
-  !> Interface to C function to inquire about LZ4 compression.
-  interface
-     function nc_inq_var_lz4(ncid, varid, lz4p, levelp) bind(c)
-       use iso_c_binding
-       integer(C_INT), value :: ncid, varid
-       integer(C_INT), intent(inout):: lz4p, levelp
-     end function nc_inq_var_lz4
-  end interface
+  ! !> Interface to C function to inquire about LZ4 compression.
+  ! interface
+  !    function nc_inq_var_lz4(ncid, varid, lz4p, levelp) bind(c)
+  !      use iso_c_binding
+  !      integer(C_INT), value :: ncid, varid
+  !      integer(C_INT), intent(inout):: lz4p, levelp
+  !    end function nc_inq_var_lz4
+  ! end interface
 
   !> Interface to C function to set BitGroom quantization.
   interface
@@ -114,43 +114,43 @@ contains
     status = nc_inq_var_bzip2(ncid, varid - 1, bzip2p, levelp)
   end function nf90_inq_var_bzip2
 
-  !> Set LZ4 compression for a variable.
-  !!
-  !! @param ncid File or group ID.
-  !! @param varid Variable ID.
-  !! @param level The compression level.
-  !!
-  !! @return 0 for sucess, error code otherwise.
-  function nf90_def_var_lz4(ncid, varid, level) result(status)
-    use iso_c_binding
-    implicit none
-    integer, intent(in) :: ncid, varid, level
-    integer :: status
+  ! !> Set LZ4 compression for a variable.
+  ! !!
+  ! !! @param ncid File or group ID.
+  ! !! @param varid Variable ID.
+  ! !! @param level The compression level.
+  ! !!
+  ! !! @return 0 for sucess, error code otherwise.
+  ! function nf90_def_var_lz4(ncid, varid, level) result(status)
+  !   use iso_c_binding
+  !   implicit none
+  !   integer, intent(in) :: ncid, varid, level
+  !   integer :: status
 
-    ! C varids start at 0, fortran at 1.
-    status = nc_def_var_lz4(ncid, varid - 1, level)
-  end function nf90_def_var_lz4
+  !   ! C varids start at 0, fortran at 1.
+  !   status = nc_def_var_lz4(ncid, varid - 1, level)
+  ! end function nf90_def_var_lz4
 
-  !> Inquire about LZ4 compression for a variable.
-  !!
-  !! @param ncid File or group ID.
-  !! @param varid Variable ID.
-  !! @param lz4p Pointer that gets 1 if LZ4 is in use, 0
-  !! otherwise. Ignored if NULL.
-  !! @param levelp Pointer that gets compression level, if LZ4 is in
-  !! use. Ignored if NULL.
-  !!
-  !! @return 0 for sucess, error code otherwise.
-  function nf90_inq_var_lz4(ncid, varid, lz4p, levelp) result(status)
-    use iso_c_binding
-    implicit none
-    integer, intent(in) :: ncid, varid
-    integer, intent(inout) :: lz4p, levelp
-    integer :: status
+  ! !> Inquire about LZ4 compression for a variable.
+  ! !!
+  ! !! @param ncid File or group ID.
+  ! !! @param varid Variable ID.
+  ! !! @param lz4p Pointer that gets 1 if LZ4 is in use, 0
+  ! !! otherwise. Ignored if NULL.
+  ! !! @param levelp Pointer that gets compression level, if LZ4 is in
+  ! !! use. Ignored if NULL.
+  ! !!
+  ! !! @return 0 for sucess, error code otherwise.
+  ! function nf90_inq_var_lz4(ncid, varid, lz4p, levelp) result(status)
+  !   use iso_c_binding
+  !   implicit none
+  !   integer, intent(in) :: ncid, varid
+  !   integer, intent(inout) :: lz4p, levelp
+  !   integer :: status
 
-    ! C varids start at 0, fortran at 1.
-    status = nc_inq_var_lz4(ncid, varid - 1, lz4p, levelp)
-  end function nf90_inq_var_lz4
+  !   ! C varids start at 0, fortran at 1.
+  !   status = nc_inq_var_lz4(ncid, varid - 1, lz4p, levelp)
+  ! end function nf90_inq_var_lz4
 
   !> Set BitGroom quantization for a variable.
   !!

--- a/include/ccr.h
+++ b/include/ccr.h
@@ -40,8 +40,6 @@ extern "C" {
     /* Library prototypes... */
     int nc_def_var_bzip2(int ncid, int varid, int level);
     int nc_inq_var_bzip2(int ncid, int varid, int *bzip2p, int *levelp);
-    int nc_def_var_lz4(int ncid, int varid, int level);
-    int nc_inq_var_lz4(int ncid, int varid, int *lz4p, int *levelp);
     int nc_def_var_bitgroom(int ncid, int varid, int nsd);
     int nc_inq_var_bitgroom(int ncid, int varid, int *bitgroomp, int *nsdp);
     int nc_def_var_zstandard(int ncid, int varid, int level);

--- a/src/ccr.c
+++ b/src/ccr.c
@@ -31,23 +31,6 @@
  * - nf90_def_var_bzip2()
  * - nf90_inq_var_bzip2()
  *
- * LZ4
- *
- * "LZ4 is a lossless data compression algorithm that is focused on
- * compression and decompression speed. It belongs to the LZ77 family
- * of byte-oriented compression schemes" (Wikipedia). For full
- * documentaton see http://lz4.github.io/lz4/. For additional info see
- * https://github.com/lz4/lz4 and
- * https://en.wikipedia.org/wiki/LZ4_(compression_algorithm).
- *
- * In C:
- * - nc_def_var_lz4()
- * - nc_inq_var_lz4()
- *
- * In Fortran:
- * - nf90_def_var_lz4()
- * - nf90_inq_var_lz4()
- *
  * BitGroom
  *
  * The BitGroom filter quantizes the mantissa of floating point values
@@ -190,96 +173,96 @@ nc_inq_var_bzip2(int ncid, int varid, int *bzip2p, int *levelp)
     return 0;
 }
 
-/**
- * Turn on lz4 compression for a variable.
- *
- * @param ncid File ID.
- * @param varid Variable ID.
- * @param level From 1 to 9. Set the block size to 100k, 200k ... 900k
- * when compressing. (lz4 default level is 9).
- *
- * @return 0 for success, error code otherwise.
- * @author Ed Hartnett
- */
-int
-nc_def_var_lz4(int ncid, int varid, int level)
-{
-    unsigned int cd_value = level;
-    int ret;
+/* /\** */
+/*  * Turn on lz4 compression for a variable. */
+/*  * */
+/*  * @param ncid File ID. */
+/*  * @param varid Variable ID. */
+/*  * @param level From 1 to 9. Set the block size to 100k, 200k ... 900k */
+/*  * when compressing. (lz4 default level is 9). */
+/*  * */
+/*  * @return 0 for success, error code otherwise. */
+/*  * @author Ed Hartnett */
+/*  *\/ */
+/* int */
+/* nc_def_var_lz4(int ncid, int varid, int level) */
+/* { */
+/*     unsigned int cd_value = level; */
+/*     int ret; */
 
-    /* Level must be between 1 and 9. */
-    if (level < 1 || level > 9)
-        return NC_EINVAL;
+/*     /\* Level must be between 1 and 9. *\/ */
+/*     if (level < 1 || level > 9) */
+/*         return NC_EINVAL; */
 
-    if (!H5Zfilter_avail(LZ4_ID))
-    {
-        printf ("lz4 filter not available.\n");
-        return NC_EFILTER;
-    }
+/*     if (!H5Zfilter_avail(LZ4_ID)) */
+/*     { */
+/*         printf ("lz4 filter not available.\n"); */
+/*         return NC_EFILTER; */
+/*     } */
 
-    /* Set up the lz4 filter for this var. */
-    if ((ret = nc_def_var_filter(ncid, varid, LZ4_ID, 1, &cd_value)))
-        return ret;
+/*     /\* Set up the lz4 filter for this var. *\/ */
+/*     if ((ret = nc_def_var_filter(ncid, varid, LZ4_ID, 1, &cd_value))) */
+/*         return ret; */
 
-    return 0;
-}
+/*     return 0; */
+/* } */
 
-/**
- * Learn whether lz4 compression is on for a variable, and, if so,
- * the level setting.
- *
- * @param ncid File ID.
- * @param varid Variable ID.
- * @param lz4p Pointer that gets a 0 if lz4 is not in use for this
- * var, and a 1 if it is. Ignored if NULL.
- * @param levelp Pointer that gets the level setting (from 1 to 9), if
- * bzlip2 is in use. Ignored if NULL.
- *
- * @return 0 for success, error code otherwise.
- * @author Ed Hartnett
- */
-int
-nc_inq_var_lz4(int ncid, int varid, int *lz4p, int *levelp)
-{
-    unsigned int level;
-    unsigned int id;
-    size_t nparams;
-    int lz4 = 0; /* Is lz4 in use? */
-    int ret;
+/* /\** */
+/*  * Learn whether lz4 compression is on for a variable, and, if so, */
+/*  * the level setting. */
+/*  * */
+/*  * @param ncid File ID. */
+/*  * @param varid Variable ID. */
+/*  * @param lz4p Pointer that gets a 0 if lz4 is not in use for this */
+/*  * var, and a 1 if it is. Ignored if NULL. */
+/*  * @param levelp Pointer that gets the level setting (from 1 to 9), if */
+/*  * bzlip2 is in use. Ignored if NULL. */
+/*  * */
+/*  * @return 0 for success, error code otherwise. */
+/*  * @author Ed Hartnett */
+/*  *\/ */
+/* int */
+/* nc_inq_var_lz4(int ncid, int varid, int *lz4p, int *levelp) */
+/* { */
+/*     unsigned int level; */
+/*     unsigned int id; */
+/*     size_t nparams; */
+/*     int lz4 = 0; /\* Is lz4 in use? *\/ */
+/*     int ret; */
 
-    /* Get filter information. */
-    ret = nc_inq_var_filter(ncid, varid, &id, &nparams, &level);
-    if (ret == NC_ENOFILTER)
-    {
-	if (lz4p)
-	    *lz4p = 0;
-	return 0;
-    }
-    else if (ret)
-	return ret;
+/*     /\* Get filter information. *\/ */
+/*     ret = nc_inq_var_filter(ncid, varid, &id, &nparams, &level); */
+/*     if (ret == NC_ENOFILTER) */
+/*     { */
+/* 	if (lz4p) */
+/* 	    *lz4p = 0; */
+/* 	return 0; */
+/*     } */
+/*     else if (ret) */
+/* 	return ret; */
 
-    /* Is lz4 in use? */
-    if (id == LZ4_ID)
-        lz4++;
+/*     /\* Is lz4 in use? *\/ */
+/*     if (id == LZ4_ID) */
+/*         lz4++; */
 
-    /* Does caller want to know if lz4 is in use? */
-    if (lz4p)
-        *lz4p = lz4;
+/*     /\* Does caller want to know if lz4 is in use? *\/ */
+/*     if (lz4p) */
+/*         *lz4p = lz4; */
 
-    /* If lz4 is in use, check parameter. */
-    if (lz4)
-    {
-        /* For lz4, there is one parameter. */
-        if (nparams != 1)
-            return NC_EFILTER;
+/*     /\* If lz4 is in use, check parameter. *\/ */
+/*     if (lz4) */
+/*     { */
+/*         /\* For lz4, there is one parameter. *\/ */
+/*         if (nparams != 1) */
+/*             return NC_EFILTER; */
 
-        /* Tell the caller, if they want to know. */
-        if (levelp)
-            *levelp = level;
-    }
+/*         /\* Tell the caller, if they want to know. *\/ */
+/*         if (levelp) */
+/*             *levelp = level; */
+/*     } */
 
-    return 0;
-}
+/*     return 0; */
+/* } */
 
 /**
  * Turn on BitGroom quantization for a variable.

--- a/src/ccr.c
+++ b/src/ccr.c
@@ -284,6 +284,14 @@ nc_inq_var_lz4(int ncid, int varid, int *lz4p, int *levelp)
 /**
  * Turn on BitGroom quantization for a variable.
  *
+ * @note Internally, the filter requires CCR_FLT_PRM_NBR (=5) elements
+ * for cd_value However, the user needs to provide only the first
+ * element, NSD, since the other elements can be and are derived from
+ * the dcpl (data_class, datum_size), and extra queries of the
+ * variable (has_mss_val, mss_val). Hence, the netCDF API exposes to
+ * the user and requires setting only the minimal number (1) of filter
+ * parameters.
+
  * @param ncid File ID.
  * @param varid Variable ID.
  * @param nsd Number of significant digits to retain. Allowed single- and
@@ -295,13 +303,6 @@ nc_inq_var_lz4(int ncid, int varid, int *lz4p, int *levelp)
 int
 nc_def_var_bitgroom(int ncid, int varid, int nsd)
 {
-  /* NB: Internally, the filter requires CCR_FLT_PRM_NBR (=5) elements for cd_value
-     However, the user needs to provide only the first element, NSD, since the other
-     elements can be and are derived from the dcpl (data_class, datum_size),
-     and extra queries of the variable (has_mss_val, mss_val).
-     Hence, the netCDF API exposes to the user and requires setting only the 
-     minimal number (1) of filter parameters.
-     Everything else should be automagical (knock on wood). */ 
   unsigned int cd_value[BITGROOM_FLT_PRM_NBR];
   int ret;
   


### PR DESCRIPTION
Fixes #117 

Updated README, no code changes.

Part of #130 

Updating docs regarding bitgroom parameters.

Part of #20 

Removed the LZ4 stuff from docs and header files. Commented out LZ4 implementation.