### PR TITLE
removed mention of LZ4, updated version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Library   | Source                                    | Notes
 netcdf-c  | https://github.com/Unidata/netcdf-c       | required
 HDF5      | https://www.hdfgroup.org/downloads/hdf5   | required
 bzip2     | https://www.sourceware.org/bzip2/         | optional
-LZ4       | https://github.com/lz4/lz4                | optional
 Zstandard | https://facebook.github.io/zstd/          | optional 
 
 ### Obtain Optional External Libraries as Pre-built Packages

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 AC_PREREQ([2.59])
 
 # Initialize with name, version, and support email address.
-AC_INIT([ccr], [1.0.0-development], [])
+AC_INIT([ccr], [1.1.0], [])
 
 AM_INIT_AUTOMAKE([foreign dist-zip subdir-objects])
 

--- a/fsrc/Makefile.am
+++ b/fsrc/Makefile.am
@@ -10,7 +10,7 @@ LIBADD = ${top_builddir}/src/libccr.la
 
 # This is a libtool library.
 lib_LTLIBRARIES = libccrf.la
-libccrf_la_LDFLAGS = -version-info 0:0:0
+libccrf_la_LDFLAGS = -version-info 1:0:0
 
 # Each convenience library depends on its source.
 libccrf_la_SOURCES = ccr.F90

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,5 +7,5 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 
 # This is a libtool library.
 lib_LTLIBRARIES = libccr.la
-libccr_la_LDFLAGS = -version-info 0:0:0
+libccr_la_LDFLAGS = -version-info 1:0:0
 libccr_la_SOURCES = ccr.c

--- a/src/ccr.c
+++ b/src/ccr.c
@@ -14,8 +14,6 @@
  * filters for netCDF/HDF5 files which are not natively supported by
  * the netCDF C library.
  *
- * @image html NetCDF_Filters.png
- *
  * BZIP2
  *
  * Bzip2 is a free and open-source file compression program that uses
@@ -74,6 +72,8 @@
  * In Fortran:
  * - nf90_def_var_zstandard()
  * - nf90_inq_var_zstandard()
+ *
+ * @image html NetCDF_Filters.png
  *
  */
 


### PR DESCRIPTION
Part of #20 

Removing mention of LZ4 in README.

Part of #82.

Updated versions.